### PR TITLE
make advertise to retry on all exceptions for now. Keep it alive.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Made ``TChannel.advertise`` retry on all exceptions
 
 
 0.10.1 (2015-07-10)

--- a/tchannel/tornado/hyperbahn.py
+++ b/tchannel/tornado/hyperbahn.py
@@ -29,8 +29,6 @@ import tornado.gen
 import tornado.ioloop
 
 from ..errors import AdvertiseError
-from ..errors import ProtocolError
-from ..errors import TimeoutError
 from .response import StatusCode
 
 DEFAULT_EXPO_BASE = 1.4  # try this first
@@ -68,7 +66,7 @@ def _advertise(tchannel, service):
             headers={'as': 'json'},
             attempt_times=1,
         )
-    except (ProtocolError, TimeoutError) as e:
+    except Exception as e:  # Big scope to keep it alive.
         log.error('Failed to register with Hyperbahn: %s', e)
     else:
         if response.code != StatusCode.ok:


### PR DESCRIPTION
@blampe @breerly @abhinav 

Currently advertise only retry for timeout error and protocol error. But when autobahn restarts, tchannel will stop advertising.  Create a large range of exception for retry for now to keep tchannel app alive. This can avoid keep updating current on-boarding service.

That's also what Node does.