### PR TITLE
rename docs to 'TChannel for Python'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-TChannel
-========
+TChannel for Python
+===================
 
-|build-status| |coverage| |docs| |pypi| 
+|build-status| |coverage| |docs| |pypi|
 
 A Python implementation of `TChannel`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
-TChannel
-========
+TChannel for Python
+===================
 
 
 |build-status| |coverage|


### PR DESCRIPTION
Other-words when you click through the main docs to the Python docs you just see "TChannel" then "TChannel".