### PR TITLE
Fix sync client using 0.0.0.0.0:0 and breaking advertise 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix sync client using ``0.0.0.0`` host which gets rejected by Hyperbahn during advertise.
 
 
 0.11.0 (2015-07-17)

--- a/tchannel/glossary.py
+++ b/tchannel/glossary.py
@@ -27,8 +27,3 @@ MAX_MESSAGE_ID = 0xfffffffe
 DEFAULT_TTL = 1000  # ms
 MAX_ATTEMPT_TIMES = 3
 RETRY_DELAY = 0.3  # 300 ms
-
-# Autobahn recognizes this hotport as ephemeral,
-# Hostport used by TChannel peers that are ephemeral and don't expect incoming
-# connections.
-EPHEMERAL_HOSTPORT = '0.0.0.0:0'

--- a/tchannel/sync/client.py
+++ b/tchannel/sync/client.py
@@ -26,7 +26,6 @@ from concurrent.futures import TimeoutError
 from threadloop import ThreadLoop
 from tornado import gen
 
-from tchannel import glossary
 from tchannel import tornado as async
 from tchannel.tornado.hyperbahn import FIRST_ADVERTISE_TIME, AdvertiseError
 
@@ -60,7 +59,6 @@ class TChannelSyncClient(object):
         """
         self.async_client = async.TChannel(
             name,
-            hostport=glossary.EPHEMERAL_HOSTPORT,
             process_name=process_name,
             known_peers=known_peers,
             trace=trace

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -85,3 +85,11 @@ def test_failing_advertise_should_raise(tchannel_server):
 
     with pytest.raises(AdvertiseError):
         client.advertise(routers, timeout=0.1)
+
+
+def test_should_discover_ip():
+
+    client = TChannelSyncClient('test-client')
+    hostport = client.async_client.hostport
+
+    assert '0.0.0.0:0' != hostport


### PR DESCRIPTION
Hyperbahn rejects all ephemeral hosts, `0.0.0.0.0`. We need to instead discover the IP.