### PR TITLE
Rename TestServer to MockServer and move to mock_server.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,11 +20,9 @@
 
 from __future__ import absolute_import
 
-import socket
-
 import pytest
 
-from tests.integration.test_server import TestServer
+from .mock_server import MockServer
 from .util import get_thrift_service_module
 
 
@@ -47,20 +45,9 @@ def connection():
     return _MockConnection()
 
 
-@pytest.fixture
-def random_open_port():
-    """Find and return a random open TCP port."""
-    sock = socket.socket(socket.AF_INET)
-    try:
-        sock.bind(('', 0))
-        return sock.getsockname()[1]
-    finally:
-        sock.close()
-
-
 @pytest.yield_fixture
-def tchannel_server(random_open_port):
-    with TestServer(random_open_port) as server:
+def mock_server():
+    with MockServer() as server:
         yield server
 
 

--- a/tests/integration/json/test_json_server.py
+++ b/tests/integration/json/test_json_server.py
@@ -27,7 +27,7 @@ import tornado.gen
 from tchannel.scheme import JsonArgScheme
 from tchannel.tornado import TChannel
 from tchannel.tornado.broker import ArgSchemeBroker
-from tests.integration.test_server import TestServer
+from tests.mock_server import MockServer
 
 
 @pytest.fixture
@@ -82,8 +82,8 @@ def register(tchannel):
 
 
 @pytest.yield_fixture
-def json_server(random_open_port):
-    with TestServer(random_open_port) as server:
+def json_server():
+    with MockServer() as server:
         register(server.tchannel)
         yield server
 
@@ -92,8 +92,7 @@ def json_server(random_open_port):
 def test_json_server(json_server, sample_json):
     endpoint = "json_echo"
     tchannel = TChannel(name='test')
-    hostport = 'localhost:%d' % json_server.port
-    client = tchannel.request(hostport)
+    client = tchannel.request(json_server.hostport)
     header = sample_json
     body = sample_json
     resp = yield ArgSchemeBroker(JsonArgScheme()).send(

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -32,10 +32,10 @@ from tests.util import big_arg
 
 
 @pytest.mark.gen_test
-def test_tornado_client_with_server_not_there(random_open_port):
+def test_tornado_client_with_server_not_there():
     with pytest.raises(ConnectionClosedError):
         yield StreamConnection.outgoing(
-            'localhost:%d' % random_open_port,
+            'localhost:%d' % 41942
         )
 
 
@@ -53,21 +53,18 @@ def test_tornado_client_with_server_not_there(random_open_port):
 ],
     ids=lambda arg: str(len(arg))
 )
-def test_tchannel_call_request_fragment(tchannel_server,
+def test_tchannel_call_request_fragment(mock_server,
                                         arg2, arg3):
     endpoint = b'tchannelpeertest'
 
-    tchannel_server.expect_call(endpoint).and_write(
+    mock_server.expect_call(endpoint).and_write(
         headers=endpoint, body=arg3
     )
 
     tchannel = TChannel(name='test')
-
-    hostport = 'localhost:%d' % (tchannel_server.port)
-
-    response = yield tchannel.request(hostport).send(InMemStream(endpoint),
-                                                     InMemStream(arg2),
-                                                     InMemStream(arg3))
+    response = yield tchannel.request(mock_server.hostport).send(
+        InMemStream(endpoint), InMemStream(arg2), InMemStream(arg3)
+    )
     header = yield response.get_header()
     body = yield response.get_body()
     assert header == endpoint
@@ -76,16 +73,16 @@ def test_tchannel_call_request_fragment(tchannel_server,
 
 
 @pytest.mark.gen_test
-def test_tcurl(tchannel_server):
+def test_tcurl(mock_server):
     endpoint = b'tcurltest'
 
-    tchannel_server.expect_call(endpoint).and_write(
+    mock_server.expect_call(endpoint).and_write(
         headers=endpoint,
         body="hello"
     )
 
     hostport = 'localhost:%d/%s' % (
-        tchannel_server.port, endpoint.decode('ascii')
+        mock_server.port, endpoint.decode('ascii')
     )
     responses = yield tcurl.main(['--host', hostport, '-d', ''])
 
@@ -100,17 +97,15 @@ def test_tcurl(tchannel_server):
 
 
 @pytest.mark.gen_test
-def test_endpoint_not_found(tchannel_server):
+def test_endpoint_not_found(mock_server):
     endpoint = b'tchanneltest'
-    tchannel_server.expect_call(endpoint).and_write(
+    mock_server.expect_call(endpoint).and_write(
         headers=endpoint,
         body='world'
     )
     tchannel = TChannel(name='test')
 
-    hostport = 'localhost:%d' % (tchannel_server.port)
-
     with pytest.raises(TChannelError):
-        yield tchannel.request(hostport).send(InMemStream(),
-                                              InMemStream(),
-                                              InMemStream())
+        yield tchannel.request(
+            mock_server.hostport
+        ).send(InMemStream(), InMemStream(), InMemStream())

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -35,7 +35,9 @@ from tests.util import big_arg
 def test_tornado_client_with_server_not_there():
     with pytest.raises(ConnectionClosedError):
         yield StreamConnection.outgoing(
-            'localhost:%d' % 41942
+            # Try a random port that we're not listening on.
+            # This should fail.
+            'localhost:41942'
         )
 
 

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -32,8 +32,6 @@ from tchannel.messages.common import FlagsType
 from tchannel.tornado import TChannel
 from tchannel.tornado.connection import StreamConnection
 
-from .test_server import TestServer
-
 
 @tornado.gen.coroutine
 def handler1(request, response, proxy):
@@ -51,20 +49,18 @@ def register(tchannel):
     tchannel.register("endpoint2", "raw", handler2)
 
 
-@pytest.yield_fixture
-def tchannel_server(random_open_port):
-    with TestServer(random_open_port) as server:
-        register(server.tchannel)
-        yield server
+@pytest.fixture
+def mock_server(mock_server):
+    register(mock_server.tchannel)
+    return mock_server
 
 
 @pytest.mark.gen_test
-def test_unexpected_error_from_handler(tchannel_server):
+def test_unexpected_error_from_handler(mock_server):
     # test for invalid call request message
-    hostport = 'localhost:%d' % tchannel_server.port
     tchannel = TChannel(name='test')
     connection = yield StreamConnection.outgoing(
-        hostport=hostport,
+        hostport=mock_server.hostport,
         tchannel=tchannel,
     )
 
@@ -83,12 +79,11 @@ def test_unexpected_error_from_handler(tchannel_server):
 
 
 @pytest.mark.gen_test
-def test_invalid_message_during_streaming(tchannel_server):
+def test_invalid_message_during_streaming(mock_server):
     # test for invalid call request message
-    hostport = 'localhost:%d' % tchannel_server.port
     tchannel = TChannel(name='test')
     connection = yield StreamConnection.outgoing(
-        hostport=hostport,
+        hostport=mock_server.hostport,
         tchannel=tchannel,
     )
 
@@ -129,12 +124,11 @@ def test_invalid_message_during_streaming(tchannel_server):
 
 
 @pytest.mark.gen_test
-def test_continue_message_error(tchannel_server):
+def test_continue_message_error(mock_server):
     # test for invalid call request message
-    hostport = 'localhost:%d' % tchannel_server.port
     tchannel = TChannel(name='test')
     connection = yield StreamConnection.outgoing(
-        hostport=hostport,
+        hostport=mock_server.hostport,
         tchannel=tchannel,
     )
 

--- a/tests/integration/thrift/test_tornado_client.py
+++ b/tests/integration/thrift/test_tornado_client.py
@@ -39,14 +39,14 @@ def mk_client(thrift_service, port, trace=False):
 
 
 @pytest.mark.gen_test
-def test_call(tchannel_server, thrift_service):
-    tchannel_server.expect_call(
+def test_call(mock_server, thrift_service):
+    mock_server.expect_call(
         thrift_service,
         'thrift',
         method='putItem',
     ).and_result(None)
 
-    client = mk_client(thrift_service, tchannel_server.port)
+    client = mk_client(thrift_service, mock_server.port)
     yield client.putItem(
         thrift_service.Item(
             key="foo",
@@ -57,14 +57,14 @@ def test_call(tchannel_server, thrift_service):
 
 
 @pytest.mark.gen_test
-def test_protocol_error(tchannel_server, thrift_service):
-    tchannel_server.expect_call(
+def test_protocol_error(mock_server, thrift_service):
+    mock_server.expect_call(
         thrift_service,
         'thrift',
         method='getItem',
     ).and_raise(ValueError("I was not defined in the IDL"))
 
-    client = mk_client(thrift_service, tchannel_server.port, trace=False)
+    client = mk_client(thrift_service, mock_server.port, trace=False)
     with pytest.raises(errors.ProtocolError):
         with patch(
             'tchannel.zipkin.tracers.TChannelZipkinTracer.record',
@@ -76,14 +76,14 @@ def test_protocol_error(tchannel_server, thrift_service):
 
 
 @pytest.mark.gen_test
-def test_thrift_exception(tchannel_server, thrift_service):
-    tchannel_server.expect_call(
+def test_thrift_exception(mock_server, thrift_service):
+    mock_server.expect_call(
         thrift_service,
         'thrift',
         method='getItem',
     ).and_raise(thrift_service.ItemDoesNotExist("stahp"))
 
-    client = mk_client(thrift_service, tchannel_server.port, trace=True)
+    client = mk_client(thrift_service, mock_server.port, trace=True)
 
     with patch(
         'tchannel.zipkin.tracers.TChannelZipkinTracer.record',

--- a/tests/integration/trace/test_zipkin_trace.py
+++ b/tests/integration/trace/test_zipkin_trace.py
@@ -27,7 +27,7 @@ import tornado.gen
 from tchannel.tornado import TChannel
 from tchannel.tornado.stream import InMemStream
 from tchannel.zipkin.zipkin_trace import ZipkinTraceHook
-from tests.integration.test_server import TestServer
+from tests.mock_server import MockServer
 
 try:
     from cStringIO import StringIO
@@ -65,8 +65,8 @@ trace_buf = StringIO()
 
 
 @pytest.yield_fixture
-def trace_server(random_open_port):
-    with TestServer(random_open_port) as server:
+def trace_server():
+    with MockServer() as server:
         register(server.tchannel)
         server.tchannel.hooks.register(
             ZipkinTraceHook(

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -29,14 +29,14 @@ from tchannel.tornado.hyperbahn import AdvertiseError
 
 
 @pytest.mark.integration
-def test_sync_client_should_get_raw_response(tchannel_server):
+def test_sync_client_should_get_raw_response(mock_server):
 
     endpoint = 'health'
-    tchannel_server.expect_call(endpoint).and_write(
+    mock_server.expect_call(endpoint).and_write(
         headers="",
         body="OK"
     )
-    hostport = tchannel_server.tchannel.hostport
+    hostport = mock_server.tchannel.hostport
 
     client = TChannelSyncClient('test-client')
     request = client.request(hostport)
@@ -49,17 +49,17 @@ def test_sync_client_should_get_raw_response(tchannel_server):
 
 
 @pytest.mark.integration
-def test_advertise_should_result_in_peer_connections(tchannel_server):
+def test_advertise_should_result_in_peer_connections(mock_server):
 
     body = {"hello": "world"}
 
-    tchannel_server.expect_call('ad', 'json').and_write(
+    mock_server.expect_call('ad', 'json').and_write(
         headers="",
         body=body,
     )
 
     routers = [
-        tchannel_server.tchannel.hostport
+        mock_server.tchannel.hostport
     ]
 
     client = TChannelSyncClient('test-client')
@@ -71,16 +71,13 @@ def test_advertise_should_result_in_peer_connections(tchannel_server):
     assert client._async_client.peers.hosts == routers
 
 
-def test_failing_advertise_should_raise(tchannel_server):
+def test_failing_advertise_should_raise(mock_server):
 
-    tchannel_server.expect_call('ad', 'json').and_raise(
+    mock_server.expect_call('ad', 'json').and_raise(
         Exception('great sadness')
     )
 
-    routers = [
-        tchannel_server.tchannel.hostport
-    ]
-
+    routers = [mock_server.tchannel.hostport]
     client = TChannelSyncClient('test-client')
 
     with pytest.raises(AdvertiseError):

--- a/tests/sync/test_thrift.py
+++ b/tests/sync/test_thrift.py
@@ -27,25 +27,22 @@ from tchannel.sync.thrift import client_for
 
 
 @pytest.fixture
-def thrift_sync_client(tchannel_server, thrift_service):
-
+def thrift_sync_client(mock_server, thrift_service):
     ServiceClient = client_for("service", thrift_service)
-
     tchannel_sync = TChannelSyncClient('test-client')
-    hostport = 'localhost:%d' % tchannel_server.port
-
-    thrift_sync_client = ServiceClient(tchannel_sync, hostport=hostport)
-
+    thrift_sync_client = ServiceClient(
+        tchannel_sync, hostport=mock_server.hostport
+    )
     return thrift_sync_client
 
 
 @pytest.mark.integration
-def test_call(tchannel_server, thrift_sync_client, thrift_service):
+def test_call(mock_server, thrift_sync_client, thrift_service):
     expected = thrift_service.Item(
         key='foo', value=thrift_service.Value(integerValue=42)
     )
 
-    tchannel_server.expect_call(
+    mock_server.expect_call(
         thrift_service,
         'thrift',
         method='getItem',

--- a/tests/tornado/test_tchannel.py
+++ b/tests/tornado/test_tchannel.py
@@ -72,18 +72,16 @@ def test_should_error_if_call_listen_twice(tchannel):
         tchannel.listen()
 
 
-def test_advertise_should_listen_if_not_called_yet(tchannel, tchannel_server):
+def test_advertise_should_listen_if_not_called_yet(tchannel, mock_server):
 
     assert tchannel.is_listening() is False
 
-    tchannel_server.expect_call('ad', 'json').and_write(
+    mock_server.expect_call('ad', 'json').and_write(
         headers="",
         body={"hello": "world"},
     )
 
-    routers = [
-        tchannel_server.tchannel.hostport
-    ]
+    routers = [mock_server.tchannel.hostport]
 
     tchannel.advertise(
         routers=routers


### PR DESCRIPTION
I decided to get these changes in separately from the VCR work to avoid conflicts later.

@blampe @breerly 