### PR TITLE
pin mock to 1.0.1 for setuptools compatibility

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -30,7 +30,7 @@ pyfarmhash==0.2.0
 crcmod
 
 # Mocks
-mock
+mock==1.0.1
 doubles
 
 # for releases


### PR DESCRIPTION
This sucks but it makes development a little easier. We also need to fix `make install` (or `make test`) to get VCR dependencies installed.

@abhinav @junchaowu @breerly 