### PR TITLE
Raise ValueError when anything but map[string]string is used for Thrift

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 0.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Raise informative and obvious ``ValueError`` when anything
+  but a map[string]string is passed as headers to the ``TChannel.thrift`` method.
 
 
 0.15.1 (2015-08-07)

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -21,11 +21,18 @@ class ThriftArgScheme(object):
     def __call__(self, request=None, headers=None, timeout=None,
                  retry_on=None, retry_limit=None):
 
-        if headers is None:
+        if not headers:
             headers = {}
 
         # serialize
-        headers = serializer.serialize_headers(headers=headers)
+        try:
+            headers = serializer.serialize_headers(headers=headers)
+        except (AttributeError, TypeError):
+            raise ValueError(
+                'headers must be a map[string]string (a shallow dict'
+                ' where keys and values are strings)'
+            )
+
         body = serializer.serialize_body(call_args=request.call_args)
 
         response = yield self._tchannel.call(

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -1144,41 +1144,24 @@ def test_value_expected_but_none_returned_should_error():
 
 
 @pytest.mark.gen_test
-@pytest.mark.callz
-def test_headers_should_be_a_map_of_strings():
+@pytest.mark.call
+@pytest.mark.parametrize('headers', [
+    {'key': 1},
+    {1: 'value'},
+    {'key': {'key': 'value'}},
+    100,
+    -100,
+    .1,
+    10 << 6,
+    True,
+    Exception(),
+])
+def test_headers_should_be_a_map_of_strings(headers):
 
     tchannel = TChannel('client')
 
     with pytest.raises(ValueError):
         yield tchannel.thrift(
             request=True,
-            headers={'key': 1},
-        )
-
-    with pytest.raises(ValueError):
-        yield tchannel.thrift(
-            request=True,
-            headers={1: 'value'},
-        )
-
-    with pytest.raises(ValueError):
-        yield tchannel.thrift(
-            request=True,
-            headers=100,
-        )
-
-    with pytest.raises(ValueError):
-        yield tchannel.thrift(
-            request=True,
-            headers={
-                'key': {
-                    'key': 'value',
-                },
-            },
-        )
-
-    with pytest.raises(ValueError):
-        yield tchannel.thrift(
-            request=True,
-            headers=Exception()
+            headers=headers,
         )

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -1141,3 +1141,44 @@ def test_value_expected_but_none_returned_should_error():
         yield tchannel.thrift(
             service.testString('no return!?')
         )
+
+
+@pytest.mark.gen_test
+@pytest.mark.callz
+def test_headers_should_be_a_map_of_strings():
+
+    tchannel = TChannel('client')
+
+    with pytest.raises(ValueError):
+        yield tchannel.thrift(
+            request=True,
+            headers={'key': 1},
+        )
+
+    with pytest.raises(ValueError):
+        yield tchannel.thrift(
+            request=True,
+            headers={1: 'value'},
+        )
+
+    with pytest.raises(ValueError):
+        yield tchannel.thrift(
+            request=True,
+            headers=100,
+        )
+
+    with pytest.raises(ValueError):
+        yield tchannel.thrift(
+            request=True,
+            headers={
+                'key': {
+                    'key': 'value',
+                },
+            },
+        )
+
+    with pytest.raises(ValueError):
+        yield tchannel.thrift(
+            request=True,
+            headers=Exception()
+        )


### PR DESCRIPTION
cc @blampe @abhinav @junchaowu 