### PR TITLE
Simplify event types (1)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 -------------------
 
 - Remove ``broker.py`` and depreciated arg scheme related code.
+- Simplify the TChannel event types. Removed ``operational_error``,
+  ``system_error`` and ``application_error``. Added ``on_error``
 
 
 0.15.2 (2015-08-07)

--- a/tchannel/event.py
+++ b/tchannel/event.py
@@ -40,12 +40,9 @@ EventType = enum(
     after_receive_request=0x21,
     before_receive_response=0x30,
     after_receive_response=0x31,
-    after_receive_system_error=0x40,
-    after_receive_system_error_per_attempt=0x41,
-    after_send_system_error=0x42,
-    on_operational_error=0x50,
-    on_operational_error_per_attempt=0x51,
-    on_application_error=0x52,
+    after_receive_error=0x41,
+    after_send_error=0x42,
+    on_exception=0x50,
 )
 
 
@@ -94,28 +91,16 @@ class EventHook(object):
         """Called after a ``CALL_RESP`` message is read."""
         pass
 
-    def after_receive_system_error(self, request, err):
+    def after_receive_error(self, request, err):
         """Called after a ``error`` message is read."""
         pass
 
-    def after_send_system_error(self, err):
+    def after_send_error(self, err):
         """Called after a ``error`` message is sent."""
         pass
 
-    def after_receive_system_error_per_attempt(self, request, err):
-        """Called after a ``error`` message is read for each attempt."""
-        pass
-
-    def on_operational_error(self, request, err):
-        """Called after an operational error happens per request."""
-        pass
-
-    def on_operational_error_per_attempt(self, request, err):
-        """Called after an operational error happens for each attempt."""
-        pass
-
-    def on_application_error(self, request, err):
-        """Called on uncaught exceptions from request handlers.
+    def on_exception(self, request, err):
+        """Called on exceptions within TChannel instance.
 
         :param request:
             The :py:class:`tchannel.tornado.request.Request` object associated

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -133,7 +133,7 @@ class RequestDispatcher(BaseRequestHandler):
                 response.id,
             )
             connection.tchannel.event_emitter.fire(
-                EventType.on_application_error,
+                EventType.on_exception,
                 request,
                 e,
             )

--- a/tchannel/zipkin/zipkin_trace.py
+++ b/tchannel/zipkin/zipkin_trace.py
@@ -79,7 +79,7 @@ class ZipkinTraceHook(EventHook):
         response.tracing.annotations.append(ann)
         self.tracer.record([(response.tracing, response.tracing.annotations)])
 
-    def after_receive_system_error(self, request, error):
+    def after_receive_error(self, request, error):
         if not error.tracing.traceflags:
             return
 
@@ -87,7 +87,7 @@ class ZipkinTraceHook(EventHook):
         error.tracing.annotations.append(ann)
         self.tracer.record([(error.tracing, error.tracing.annotations)])
 
-    def after_send_system_error(self, error):
+    def after_send_error(self, error):
         if not error.tracing.traceflags:
             return
 

--- a/tests/tornado/test_dispatch.py
+++ b/tests/tornado/test_dispatch.py
@@ -93,7 +93,7 @@ def test_uncaught_exceptions_fire_event_hook(dispatcher, req, connection):
     yield dispatcher.handle_call(req, connection)
 
     connection.tchannel.event_emitter.fire.assert_called_with(
-        EventType.on_application_error,
+        EventType.on_exception,
         req,
         mock.ANY,
     )


### PR DESCRIPTION
This is first patch of a serial patches about refactoring events and retry.
The first one is intended to remove unnecessary event.