### PR TITLE
allow ctrl-c'ing benchmark examples

### DIFF
--- a/examples/benchmark/thrift/client.py
+++ b/examples/benchmark/thrift/client.py
@@ -66,6 +66,9 @@ def do_work():
         local.requests += 1
 
 
-ioloop.PeriodicCallback(report_work, 1000).start()
-
-resp = ioloop.IOLoop.current().run_sync(do_work)
+if __name__ == '__main__':
+    ioloop.PeriodicCallback(report_work, 1000).start()
+    try:
+        ioloop.IOLoop.current().run_sync(do_work)
+    except KeyboardInterrupt:
+        pass

--- a/examples/benchmark/thrift/server.py
+++ b/examples/benchmark/thrift/server.py
@@ -57,4 +57,7 @@ def run():
 
 if __name__ == '__main__':
     run()
-    ioloop.IOLoop.current().start()
+    try:
+        ioloop.IOLoop.current().start()
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
This makes them more compatible with plop.

@abhinav @junchaowu @breerly 