### PR TITLE
improvments for exception handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ Changelog
   the new server API. See the upgrade guide for details.
 - **BREAKING** - remove ``retry_delay`` option in the ``tchannel.tornado.send``
   method.
+- **BREAKING** - error types have been reworked significantly. In particular,
+  the all-encompassing ``ProtocolError`` has been replaced with more
+  granualar/actionable exceptions. See the upgrade guide for more info.
+
 
 
 0.15.2 (2015-08-07)

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -39,6 +39,27 @@ From 0.15 to 0.16
 
   After: no more ``retry_delay`` in  ``tchannel.tornado.TChannel.request.send()``
 
+- If you were catching ``ProtocolError`` you will need to catch a more specific
+  type, such as ``TimeoutError``, ``BadRequestError``, ``NetworkError``,
+  ``UnhealthyError``, or ``UnexpectedError``.
+
+- If you were catching ``AdvertiseError``, it has been replaced by
+  ``TimeoutError``.
+
+- If you were catching ``BadRequest``, it may have been masking checksum errors
+  and fatal streaming errors. These are now raised as ``FatalProtocolError``,
+  but in practive should not need to be handled when interacting with a
+  well-behaved TChannel implementation.
+
+- ``TChannelApplicationError`` was unused and removed.
+
+- Three error types have been introduced to simplify retry handling:
+  ``UnretryableError`` (for requests should never be retried),
+  ``AlwaysRetryableError`` (for requests that are always safe to retry), and
+  ``PossiblyRetryableError`` (for requests that are safe to retry on idempotent
+  endpoints).
+
+
 From 0.14 to 0.15
 -----------------
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -55,9 +55,9 @@ From 0.15 to 0.16
 - ``TChannelApplicationError`` was unused and removed.
 
 - Three error types have been introduced to simplify retry handling:
-  ``UnretryableError`` (for requests should never be retried),
-  ``AlwaysRetryableError`` (for requests that are always safe to retry), and
-  ``PossiblyRetryableError`` (for requests that are safe to retry on idempotent
+  ``NotRetryableError`` (for requests should never be retried),
+  ``RetryableError`` (for requests that are always safe to retry), and
+  ``MaybeRetryableError`` (for requests that are safe to retry on idempotent
   endpoints).
 
 

--- a/tchannel/errors.py
+++ b/tchannel/errors.py
@@ -70,51 +70,51 @@ class TChannelError(Exception):
         }[code](**kw)
 
 
-class AlwaysRetryableError(TChannelError):
+class RetryableError(TChannelError):
     pass
 
 
-class PossiblyRetryableError(TChannelError):
+class MaybeRetryableError(TChannelError):
     pass
 
 
-class UnretryableError(TChannelError):
+class NotRetryableError(TChannelError):
     pass
 
 
-class TimeoutError(PossiblyRetryableError):
+class TimeoutError(MaybeRetryableError):
     code = TIMEOUT
 
 
-class CanceledError(UnretryableError):
+class CanceledError(NotRetryableError):
     code = CANCELED
 
 
-class BusyError(AlwaysRetryableError):
+class BusyError(RetryableError):
     code = BUSY
 
 
-class DeclinedError(AlwaysRetryableError):
+class DeclinedError(RetryableError):
     code = DECLINED
 
 
-class UnexpectedError(PossiblyRetryableError):
+class UnexpectedError(MaybeRetryableError):
     code = UNEXPECTED_ERROR
 
 
-class BadRequestError(UnretryableError):
+class BadRequestError(NotRetryableError):
     code = BAD_REQUEST
 
 
-class NetworkError(PossiblyRetryableError):
+class NetworkError(MaybeRetryableError):
     code = NETWORK_ERROR
 
 
-class UnhealthyError(UnretryableError):
+class UnhealthyError(NotRetryableError):
     code = UNHEALTHY
 
 
-class FatalProtocolError(UnretryableError):
+class FatalProtocolError(NotRetryableError):
     code = FATAL
 
 
@@ -128,7 +128,7 @@ class InvalidChecksumError(FatalProtocolError):
     pass
 
 
-class NoAvailablePeerError(AlwaysRetryableError):
+class NoAvailablePeerError(RetryableError):
     """Represents a failure to find any peers for a request."""
     pass
 

--- a/tchannel/sync/client.py
+++ b/tchannel/sync/client.py
@@ -26,8 +26,8 @@ from concurrent.futures import TimeoutError
 from tornado import gen
 
 from tchannel import tornado as async
+from tchannel import errors
 from tchannel.tornado.hyperbahn import FIRST_ADVERTISE_TIME
-from tchannel.tornado.hyperbahn import AdvertiseError
 from threadloop import ThreadLoop
 
 
@@ -124,7 +124,7 @@ class TChannelSyncClient(object):
         try:
             result = future.result(wait_until)
         except TimeoutError:
-            raise AdvertiseError(
+            raise errors.TimeoutError(
                 "Failed to register with Hyperbahn."
             )
 

--- a/tchannel/testing/vcr/patch.py
+++ b/tchannel/testing/vcr/patch.py
@@ -27,7 +27,7 @@ import contextlib2
 from tornado import gen
 
 from tchannel import schemes
-from tchannel.errors import ProtocolError
+from tchannel.errors import TChannelError
 from tchannel.tornado import TChannel
 from tchannel.tornado.response import Response
 from tchannel.tornado.stream import maybe_stream
@@ -100,8 +100,8 @@ class PatchedClientOperation(object):
         try:
             vcr_response = yield vcr_response_future
         except VCRProxy.RemoteServiceError as e:
-            raise ProtocolError(
-                code=e.code,
+            raise TChannelError.from_code(
+                e.code,
                 description=(
                     "The remote service threw a protocol error: %s" %
                     e.message

--- a/tchannel/testing/vcr/server.py
+++ b/tchannel/testing/vcr/server.py
@@ -24,7 +24,7 @@ from functools import wraps
 
 from tornado import gen
 
-from tchannel.errors import ProtocolError
+from tchannel.errors import TChannelError
 from tchannel.tornado import TChannel
 
 from .proxy import VCRProxy
@@ -128,7 +128,7 @@ class VCRProxyService(object):
         # Don't actually yield while everything is unpatched.
         try:
             response = yield response_future
-        except ProtocolError as e:
+        except TChannelError as e:
             raise VCRProxy.RemoteServiceError(
                 code=e.code,
                 message=e.message,

--- a/tchannel/tornado/hyperbahn.py
+++ b/tchannel/tornado/hyperbahn.py
@@ -28,7 +28,7 @@ import time
 import tornado.gen
 import tornado.ioloop
 
-from ..errors import AdvertiseError
+from ..errors import TimeoutError
 from .response import StatusCode
 
 EXPO_BASE = 1.4  # try this first
@@ -85,7 +85,7 @@ def _advertise_with_backoff(tchannel, service, timeout=None):
 
     while True:
         if timeout and time.time() - start > timeout:
-            raise AdvertiseError("Failed to register with Hyperbahn.")
+            raise TimeoutError("Failed to register with Hyperbahn.")
 
         response = yield _advertise(tchannel, service)
 

--- a/tchannel/tornado/stream.py
+++ b/tchannel/tornado/stream.py
@@ -27,7 +27,7 @@ import tornado.ioloop
 from tornado.iostream import PipeIOStream
 from tornado.iostream import StreamClosedError
 
-from ..errors import StreamingError
+from ..errors import UnexpectedError
 from ..messages import common
 from ..messages.common import StreamState
 
@@ -77,8 +77,8 @@ class Stream(object):
     def write(self, chunk):
         """Async write to internal stream buffer
 
-        :raises StreamingError:
-            if stream has been closed, it will raise StreamingError
+        :raises UnexpectedError:
+            if stream has been closed, it will raise UnexpectedError
         """
         raise NotImplementedError()
 
@@ -152,7 +152,7 @@ class InMemStream(Stream):
             raise self.exception
 
         if self.state == StreamState.completed:
-            raise StreamingError("Stream has been closed.")
+            raise UnexpectedError("Stream has been closed.")
 
         if chunk:
             self._stream.append(chunk)
@@ -235,7 +235,7 @@ class PipeStream(Stream):
             self.state = StreamState.streaming
         except StreamClosedError:
             self.state = StreamState.completed
-            raise StreamingError("Stream has been closed.")
+            raise UnexpectedError("Stream has been closed.")
         finally:
             if self.exception:
                 raise self.exception

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import pytest
 
 from tchannel import tcurl
-from tchannel.errors import ConnectionClosedError
+from tchannel.errors import NetworkError
 from tchannel.errors import TChannelError
 from tchannel.tornado import TChannel
 from tchannel.tornado.connection import StreamConnection
@@ -33,7 +33,7 @@ from tests.util import big_arg
 
 @pytest.mark.gen_test
 def test_tornado_client_with_server_not_there():
-    with pytest.raises(ConnectionClosedError):
+    with pytest.raises(NetworkError):
         yield StreamConnection.outgoing(
             # Try a random port that we're not listening on.
             # This should fail.

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -28,7 +28,7 @@ import tornado.gen
 from mock import patch
 
 from tchannel import retry
-from tchannel.errors import ProtocolError
+from tchannel.errors import BusyError
 from tchannel.errors import TChannelError
 from tchannel.errors import TimeoutError
 from tchannel.messages import ErrorCode
@@ -113,7 +113,7 @@ def test_retry_on_error_fail():
         )
     ) as mock_should_retry_on_error:
         mock_should_retry_on_error.return_value = True
-        with pytest.raises(ProtocolError) as e:
+        with pytest.raises(BusyError) as e:
             yield tchannel.request(
                 score_threshold=0
             ).send(
@@ -210,5 +210,5 @@ def test_should_retry_on_error(retry_flag, error_code, result):
         headers={'re': retry_flag},
     )
 
-    error = ProtocolError(code=error_code, description="retry")
+    error = TChannelError.from_code(error_code, description="retry")
     assert request.should_retry_on_error(error) == result

--- a/tests/integration/thrift/test_tornado_client.py
+++ b/tests/integration/thrift/test_tornado_client.py
@@ -57,7 +57,7 @@ def test_call(mock_server, thrift_service):
 
 
 @pytest.mark.gen_test
-def test_protocol_error(mock_server, thrift_service):
+def test_unexpected_error(mock_server, thrift_service):
     mock_server.expect_call(
         thrift_service,
         'thrift',
@@ -65,7 +65,7 @@ def test_protocol_error(mock_server, thrift_service):
     ).and_raise(ValueError("I was not defined in the IDL"))
 
     client = mk_client(thrift_service, mock_server.port, trace=False)
-    with pytest.raises(errors.ProtocolError):
+    with pytest.raises(errors.UnexpectedError):
         with patch(
             'tchannel.zipkin.tracers.TChannelZipkinTracer.record',
             autospec=True,

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -32,7 +32,7 @@ from tchannel import response
 from tchannel import schemes
 from tchannel import thrift_request_builder
 from tchannel.errors import OneWayNotSupportedError
-from tchannel.errors import ProtocolError
+from tchannel.errors import UnexpectedError
 from tchannel.errors import ValueExpectedError
 from tchannel.testing.data.generated.ThriftTest import SecondService
 from tchannel.testing.data.generated.ThriftTest import ThriftTest
@@ -856,7 +856,7 @@ def test_exception():
         assert e.value.message == 'Xception'
 
     # case #2
-    with pytest.raises(ProtocolError):
+    with pytest.raises(UnexpectedError):
         yield tchannel.thrift(
             service.testException(arg='TException')
         )
@@ -1106,7 +1106,7 @@ def test_call_response_should_contain_transport_headers():
 
 @pytest.mark.gen_test
 @pytest.mark.call
-def test_call_unexpected_error_should_result_in_protocol_error():
+def test_call_unexpected_error_should_result_in_unexpected_error():
 
     # Given this test server:
 
@@ -1128,7 +1128,7 @@ def test_call_unexpected_error_should_result_in_protocol_error():
         hostport=server.hostport,
     )
 
-    with pytest.raises(ProtocolError):
+    with pytest.raises(UnexpectedError):
         yield tchannel.thrift(
             service.testMultiException(arg0='Xception', arg1='thingy')
         )

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -25,7 +25,7 @@ import json
 import pytest
 
 from tchannel.sync import TChannelSyncClient
-from tchannel.tornado.hyperbahn import AdvertiseError
+from tchannel.errors import TimeoutError
 
 
 @pytest.mark.integration
@@ -80,7 +80,7 @@ def test_failing_advertise_should_raise(mock_server):
     routers = [mock_server.tchannel.hostport]
     client = TChannelSyncClient('test-client')
 
-    with pytest.raises(AdvertiseError):
+    with pytest.raises(TimeoutError):
         client.advertise(routers, timeout=0.1)
 
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import pytest
 from mock import MagicMock
 
-from tchannel.errors import ProtocolError
+from tchannel.errors import TChannelError
 from tchannel.errors import TimeoutError
 from tchannel.messages import ErrorCode
 from tchannel.statsd import StatsdHook
@@ -70,7 +70,7 @@ def test_after_receive_response(statsd_hook, request):
 
 
 def test_after_receive_system_error(statsd_hook, request):
-    error = ProtocolError(code=ErrorCode.bad_request, description="")
+    error = TChannelError.from_code(ErrorCode.bad_request)
     statsd_hook.after_receive_system_error(request, error)
     statsd_hook._statsd.count.assert_called_with(
         "tchannel.outbound.calls.system-errors.no-service." +
@@ -79,7 +79,7 @@ def test_after_receive_system_error(statsd_hook, request):
 
 
 def test_after_receive_system_error_per_attempt(statsd_hook, request):
-    error = ProtocolError(code=ErrorCode.bad_request, description="")
+    error = TChannelError.from_code(code=ErrorCode.bad_request)
     statsd_hook.after_receive_system_error_per_attempt(request, error)
     statsd_hook._statsd.count.assert_called_with(
         "tchannel.outbound.calls.per-attempt.system-errors.no-service." +

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -24,7 +24,7 @@ import os
 
 import pytest
 
-from tchannel.errors import StreamingError
+from tchannel.errors import UnexpectedError
 from tchannel.errors import TChannelError
 from tchannel.tornado import Response
 from tchannel.tornado.stream import InMemStream
@@ -47,7 +47,7 @@ def test_InMemStream():
     assert len(stream._stream) == 0
 
     stream.close()
-    with pytest.raises(StreamingError):
+    with pytest.raises(UnexpectedError):
         yield stream.write("4")
 
 
@@ -65,7 +65,7 @@ def test_PipeStream():
     assert buf == "3"
 
     stream.close()
-    with pytest.raises(StreamingError):
+    with pytest.raises(UnexpectedError):
         yield stream.write("4")
 
 
@@ -74,7 +74,7 @@ def test_response_exception():
     resp = Response()
     yield resp.write_body("aaa")
 
-    with pytest.raises(StreamingError):
+    with pytest.raises(UnexpectedError):
         yield resp.write_header("aaa")
 
     resp.flush()

--- a/tests/testing/vcr/integration/test_vcr.py
+++ b/tests/testing/vcr/integration/test_vcr.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import pytest
 from tornado import gen
 
-from tchannel.errors import ProtocolError
+from tchannel.errors import UnexpectedError
 from tchannel.thrift import client_for
 from tchannel.tornado import TChannel
 from tchannel.testing import vcr
@@ -105,7 +105,7 @@ def test_protocol_exception(tmpdir, mock_server, call):
         Exception('great sadness')
     ).once()
 
-    with pytest.raises(ProtocolError):
+    with pytest.raises(UnexpectedError):
         with vcr.use_cassette(str(path)):
             yield call('hello', 'world')
 
@@ -163,7 +163,7 @@ def test_use_cassette_as_decorator_with_inject(tmpdir, mock_server, call):
     @gen.coroutine
     @vcr.use_cassette(str(path), inject=True)
     def f(cassette):
-        with pytest.raises(ProtocolError):
+        with pytest.raises(UnexpectedError):
             yield call('hello', 'world', service='hello_service')
 
         assert len(cassette.data) == 0

--- a/tests/testing/vcr/test_server.py
+++ b/tests/testing/vcr/test_server.py
@@ -26,7 +26,7 @@ from doubles import InstanceDouble, allow, expect
 from contextlib2 import contextmanager
 
 from tchannel.thrift import client_for
-from tchannel.errors import ProtocolError
+from tchannel.errors import TChannelError
 from tchannel.tornado import TChannel
 from tchannel.tornado.stream import InMemStream
 from tchannel.testing.vcr.proxy import VCRProxy
@@ -162,7 +162,7 @@ def test_protocol_error(vcr_service, cassette, call, mock_server):
     expect(cassette).record.never()
 
     mock_server.expect_call('endpoint').and_error(
-        ProtocolError(code=1, description='great sadness')
+        TChannelError.from_code(1, description='great sadness')
     )
 
     with pytest.raises(VCRProxy.RemoteServiceError) as exc_info:

--- a/tests/tornado/test_hyperbahn.py
+++ b/tests/tornado/test_hyperbahn.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import pytest
 import tornado
 
-from tchannel.errors import ConnectionClosedError
+from tchannel.errors import NetworkError
 from tchannel.tornado import TChannel
 from tchannel.tornado import hyperbahn
 
@@ -51,7 +51,7 @@ def test_request():
 
     # Just want to make sure all the plumbing fits together.
 
-    with pytest.raises(ConnectionClosedError):
+    with pytest.raises(NetworkError):
         yield channel.request(service='bar').send(
             arg1='baz',
             arg2='bam',


### PR DESCRIPTION
Please pay attention to the hierarchy in `errors.py` and the exceptions we're now catching in tests. Compare these against [the spec](http://tchannel.readthedocs.org/en/latest/protocol/#code1_1).

* Get rid of `ProtocolError`. That's a very particular error (`0xff`) that we don't want everything subclassing. 
* Add `AlwaysRetryableError`, `PossiblyRetryableError`, and `UnretryableError` to make the individual exceptions more actionable.
* Got rid of some of the other exception classes like `TChannelApplicationError` (unused), `ConnectionClosedError` (already captured by `NetworkError`), `InvalidEndpointError ` (already captured by `BadRequest`), etc. 
* We were catching `InvalidChecksumError` and `StreamingError` and always returning those as `BadRequest`, now we return the original error.
* Switched the default handler to not use defaultdict because it's slow.
* I'm duplicating error codes (they're already in the message definition) but I didn't want this file importing from messages because it shouldn't have any dependencies.