### PR TITLE
update not_found handler for new server API

### DIFF
--- a/tchannel/request.py
+++ b/tchannel/request.py
@@ -35,13 +35,21 @@ class Request(object):
     __slots__ = (
         'body',
         'headers',
-        'transport'
+        'transport',
+        'endpoint',
     )
 
-    def __init__(self, body=None, headers=None, transport=None):
+    def __init__(
+        self,
+        body=None,
+        headers=None,
+        transport=None,
+        endpoint=None,
+    ):
         self.body = body
         self.headers = headers
         self.transport = transport
+        self.endpoint = endpoint
 
 
 class TransportHeaders(object):

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -65,11 +65,8 @@ class RequestDispatcher(object):
     FALLBACK = object()
 
     def __init__(self, _handler_returns_response=False):
-        self.handlers = {
-            self.FALLBACK: Handler(
-                self.not_found, RawSerializer(), RawSerializer()
-            )
-        }
+        self.handlers = {}
+        self.register(self.FALLBACK, self.not_found)
         self._handler_returns_response = _handler_returns_response
 
     _HANDLER_NAMES = {
@@ -181,6 +178,7 @@ class RequestDispatcher(object):
                     body=b,
                     headers=he,
                     transport=t,
+                    endpoint=request.endpoint,
                 )
 
                 # Not safe to have coroutine yields statement within
@@ -271,11 +269,10 @@ class RequestDispatcher(object):
         self.handlers[rule] = Handler(handler, req_serializer, resp_serializer)
 
     @staticmethod
-    def not_found(request, response):
+    def not_found(request, response=None):
         """Default behavior for requests to unrecognized endpoints."""
         raise BadRequestError(
-            description="Endpoint '%s' for service '%s' is not defined" % (
+            description="Endpoint '%s' is not defined" % (
                 request.endpoint,
-                request.service,
             ),
         )

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -29,7 +29,7 @@ import textwrap
 import psutil
 import pytest
 
-from tchannel import TChannel, Request, Response, schemes
+from tchannel import TChannel, Request, Response, schemes, errors
 from tchannel.response import TransportHeaders
 
 # TODO - need integration tests for timeout and retries, use testing.vcr
@@ -227,3 +227,19 @@ def test_endpoint_can_be_called_as_a_pure_func():
     assert isinstance(resp, Response)
     assert resp.headers == 'resp headers'
     assert resp.body == 'resp body'
+
+
+@pytest.mark.gen_test
+@pytest.mark.call
+def test_endpoint_not_found():
+    server = TChannel(name='server')
+    server.listen()
+
+    tchannel = TChannel(name='client')
+
+    with pytest.raises(errors.BadRequestError):
+        yield tchannel.raw(
+            service='server',
+            hostport=server.hostport,
+            endpoint='foo',
+        )


### PR DESCRIPTION
This was failing because sometimes we pass req/res and sometimes we just pass req.

@breerly @abhinav @junchaowu 