### PR TITLE
Run VCR server in a separate thread with dedicated IOLoop.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes by Version
 
 - Fixed a bug where the 'not found' handler would incorrectly return
   serialization mismatch errors..
+- Fixed a bug which prevented VCR support from working with the sync client.
 
 
 0.16.0 (2015-08-25)

--- a/tchannel/testing/vcr/server.py
+++ b/tchannel/testing/vcr/server.py
@@ -20,9 +20,11 @@
 
 from __future__ import absolute_import
 
+import threading
 from functools import wraps
 
 from tornado import gen
+from tornado.ioloop import IOLoop
 
 from tchannel.errors import TChannelError
 from tchannel.tornado import TChannel
@@ -75,8 +77,11 @@ class VCRProxyService(object):
         self.unpatch = unpatch
         self.cassette = cassette
 
-        self.tchannel = TChannel('proxy-server')
-        self.tchannel.register(VCRProxy, handler=self.send)
+        self.io_loop = None
+        self.thread = None
+        self.tchannel = None
+
+        self._running = threading.Event()
 
     @wrap_uncaught(reraise=(
         VCRProxy.CannotRecordInteractionsError,
@@ -148,11 +153,32 @@ class VCRProxyService(object):
     def hostport(self):
         return self.tchannel.hostport
 
-    def start(self):
+    def _run(self):
+        self.io_loop = IOLoop()
+        self.io_loop.make_current()
+
+        self.tchannel = TChannel('proxy-server')
+        self.tchannel.register(VCRProxy, handler=self.send)
+
         self.tchannel.listen()
+        self._running.set()
+        self.io_loop.start()
+
+    def start(self):
+        self.thread = threading.Thread(target=self._run)
+        self.thread.start()
+
+        self._running.wait(1)
 
     def stop(self):
         self.tchannel.close()
+        self.tchannel = None
+
+        self.io_loop.stop()
+        self.io_loop = None
+
+        self.thread.join(1)  # seconds
+        self.thread = None
 
     def __enter__(self):
         self.start()

--- a/tests/testing/vcr/integration/test_sync_client.py
+++ b/tests/testing/vcr/integration/test_sync_client.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import
+
+import pytest
+
+from tchannel.errors import UnexpectedError
+from tchannel.sync import TChannel
+from tchannel.thrift import thrift_request_builder
+from tchannel.testing import vcr
+
+
+@pytest.mark.gen_test
+def test_record_success(tmpdir, mock_server):
+    path = tmpdir.join('data.yaml')
+    mock_server.expect_call('hello').and_write('world').once()
+
+    client = TChannel('test')
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+            hostport=mock_server.hostport,
+        ).result(timeout=1)
+
+        assert 'world' == response.body
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+            hostport=mock_server.hostport,
+        ).result(timeout=1)
+        assert 'world' == response.body
+
+    assert cass.play_count == 1
+
+
+@pytest.mark.gen_test
+def test_record_success_new_channels(tmpdir, mock_server):
+    path = tmpdir.join('data.yaml')
+    mock_server.expect_call(
+        'hello', scheme='json',
+    ).and_write('world').once()
+
+    with vcr.use_cassette(str(path)) as cass:
+        client = TChannel('test')
+        response = client.json(
+            'hello_service',
+            'hello',
+            'world',
+            hostport=mock_server.hostport,
+        ).result(timeout=1)
+
+        assert 'world' == response.body
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        client = TChannel('test')
+        response = client.json(
+            'hello_service',
+            'hello',
+            'world',
+            hostport=mock_server.hostport,
+        ).result(timeout=1)
+        assert 'world' == response.body
+
+    assert cass.play_count == 1
+
+
+@pytest.mark.gen_test
+def test_record_success_thrift(tmpdir, thrift_service, mock_server):
+    myservice = thrift_request_builder(
+        'myservice', thrift_service, hostport=mock_server.hostport
+    )
+
+    path = tmpdir.join('data.yaml')
+    expected_item = thrift_service.Item(
+        'foo', thrift_service.Value(stringValue='bar')
+    )
+    mock_server.expect_call(thrift_service, method='getItem').and_result(
+        expected_item
+    ).once()
+
+    client = TChannel('test')
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.thrift(myservice.getItem('foo')).result(1)
+        item = response.body
+        assert item == expected_item
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.thrift(myservice.getItem('foo')).result(1)
+        item = response.body
+        assert item == expected_item
+
+    assert cass.play_count == 1
+
+
+@pytest.mark.gen_test
+def test_protocol_exception(tmpdir, mock_server):
+    path = tmpdir.join('data.yaml')
+
+    mock_server.expect_call('hello').and_raise(
+        Exception('great sadness')
+    ).once()
+
+    with pytest.raises(UnexpectedError):
+        with vcr.use_cassette(str(path)):
+            client = TChannel('test')
+            client.raw(
+                'hello_service',
+                'hello',
+                'world',
+                hostport=mock_server.hostport,
+            ).result(1)
+
+    assert not path.check()  # nothing should've been recorded
+
+
+@pytest.mark.gen_test
+def test_record_thrift_exception(tmpdir, mock_server, thrift_service):
+    path = tmpdir.join('data.yaml')
+
+    myservice = thrift_request_builder(
+        'myservice', thrift_service, hostport=mock_server.hostport
+    )
+
+    mock_server.expect_call(thrift_service, method='getItem').and_raise(
+        thrift_service.ItemDoesNotExist('foo')
+    ).once()
+
+    client = TChannel('test')
+
+    with vcr.use_cassette(str(path)) as cass:
+        with pytest.raises(thrift_service.ItemDoesNotExist):
+            client.thrift(myservice.getItem('foo')).result(1)
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        with pytest.raises(thrift_service.ItemDoesNotExist):
+            client.thrift(myservice.getItem('foo')).result(1)
+
+    assert cass.play_count == 1

--- a/tests/testing/vcr/integration/test_vcr.py
+++ b/tests/testing/vcr/integration/test_vcr.py
@@ -22,51 +22,117 @@ from __future__ import absolute_import
 
 import pytest
 from tornado import gen
+from functools import partial
 
 from tchannel.errors import UnexpectedError
 from tchannel.thrift import client_for
-from tchannel.tornado import TChannel
 from tchannel.testing import vcr
 
 
-@pytest.fixture
-def call(mock_server):
-    channel = TChannel('test-client')
+@pytest.fixture(params=[True, False], ids=('old', 'new'))
+def use_old_api(request):
+    return request.param
 
-    def f(endpoint, body, headers=None, service=None, scheme=None):
-        return channel.request(
+
+@pytest.fixture
+def get_body(use_old_api):
+    if use_old_api:
+        return (lambda r: r.get_body())
+    else:
+        @gen.coroutine
+        def new_get_body(r):
+            return r.body
+        return new_get_body
+
+
+@pytest.fixture
+def call(mock_server, use_old_api):
+    if use_old_api:
+        from tchannel.tornado import TChannel
+
+        channel = TChannel('test-client')
+
+        def old_f(endpoint, body, headers=None, service=None, scheme=None):
+            return channel.request(
+                hostport=mock_server.hostport,
+                service=service,
+                arg_scheme=scheme,
+            ).send(endpoint, headers or '', body)
+
+        return old_f
+    else:
+        from tchannel import TChannel
+
+        channel = TChannel('test-client')
+
+        def new_f(endpoint, body, headers=None, service=None, scheme=None):
+            scheme = scheme or 'raw'
+            return channel.call(
+                hostport=mock_server.hostport,
+                scheme=scheme,
+                service=service,
+                arg1=endpoint,
+                arg2=headers or '',
+                arg3=body,
+            )
+
+        return new_f
+
+
+@pytest.fixture
+def thrift_client(thrift_service, mock_server, use_old_api):
+    if use_old_api:
+        from tchannel.tornado import TChannel
+
+        return client_for('myservice', thrift_service)(
+            tchannel=TChannel('thrift-client'),
             hostport=mock_server.hostport,
-            service=service,
-            arg_scheme=scheme,
-        ).send(endpoint, headers or '', body)
+        )
+    else:
+        from tchannel import TChannel
+        from tchannel.thrift import thrift_request_builder
 
-    return f
+        myservice = thrift_request_builder(
+            'myservice', thrift_service, hostport=mock_server.hostport
+        )
+        return mk_fake_client(
+            TChannel('thrift-client'),
+            myservice
+        )
 
 
-@pytest.fixture
-def thrift_client(thrift_service, mock_server):
-    return client_for('myservice', thrift_service)(
-        tchannel=TChannel('thrift-client'),
-        hostport=mock_server.hostport,
-    )
+def mk_fake_client(channel, builder):
+
+    class Client(object):
+
+        @gen.coroutine
+        def _call(self, name, *args, **kwargs):
+            req = getattr(builder, name)(*args, **kwargs)
+            res = yield channel.thrift(req)
+            raise gen.Return(res.body)
+
+        def __getattr__(self, name):
+            return partial(self._call, name)
+
+    return Client()
 
 
 @pytest.mark.gen_test
-def test_record_success(tmpdir, mock_server, call):
+def test_record_success(tmpdir, mock_server, call, get_body):
     path = tmpdir.join('data.yaml')
 
     mock_server.expect_call('hello').and_write('world').once()
 
     with vcr.use_cassette(str(path)) as cass:
         response = yield call('hello', 'world', service='hello_service')
-        assert 'world' == (yield response.get_body())
+        assert 'world' == (yield get_body(response))
 
     assert cass.play_count == 0
     assert path.check(file=True)
 
     with vcr.use_cassette(str(path)) as cass:
         response = yield call('hello', 'world', service='hello_service')
-        assert 'world' == (yield response.get_body())
+        assert 'world' == (yield get_body(response))
 
     assert cass.play_count == 1
 
@@ -107,7 +173,7 @@ def test_protocol_exception(tmpdir, mock_server, call):
 
     with pytest.raises(UnexpectedError):
         with vcr.use_cassette(str(path)):
-            yield call('hello', 'world')
+            yield call('hello', 'world', service='hello_service')
 
     assert not path.check()  # nothing should've been recorded
 
@@ -137,7 +203,7 @@ def test_record_thrift_exception(
 
 
 @pytest.mark.gen_test
-def test_use_cassette_as_decorator(tmpdir, mock_server, call):
+def test_use_cassette_as_decorator(tmpdir, mock_server, call, get_body):
     path = tmpdir.join('data.yaml')
     mock_server.expect_call('hello').and_write('world').once()
 
@@ -145,7 +211,7 @@ def test_use_cassette_as_decorator(tmpdir, mock_server, call):
     @vcr.use_cassette(str(path))
     def f():
         response = yield call('hello', 'world', service='hello_service')
-        body = yield response.get_body()
+        body = yield get_body(response)
         raise gen.Return(body)
 
     body = yield f()


### PR DESCRIPTION
Add tests for VCR-sync client integration.

Fixes #138.

@blampe @breerly @junchaowu 