### PR TITLE
[vcr] Account for known_peers when making requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,9 @@ Changes by Version
 -------------------
 
 - Fixed a bug where the 'not found' handler would incorrectly return
-  serialization mismatch errors..
-- Fixed a bug which prevented VCR support from working with the sync client.
+  serialization mismatch errors.
+- Fixed a bug in VCR that prevented it from recording requests made by the sync
+  client, and requests made with ``hostport=None``.
 
 
 0.16.0 (2015-08-25)

--- a/tchannel/testing/vcr/proxy.thrift
+++ b/tchannel/testing/vcr/proxy.thrift
@@ -22,9 +22,22 @@ struct Request {
     3: optional binary headers = ""
     4: required binary body
 
+    /**
+     * Remote hostport to which the request will be sent.
+     *
+     * If specified, the request will be made to this host only.
+     */
     5: optional binary hostPort = ""
     6: optional ArgScheme argScheme = ArgScheme.RAW
     7: optional list<TransportHeader> transportHeaders = {}
+
+    /**
+     * List of known peers of the TChannel at the time the request was made.
+     *
+     * This MUST be specified if hostPort wasn't. The request will be sent to
+     * a random peer from the list.
+     */
+    8: optional list<binary> knownPeers = []
     // TODO: retry flags
     // TODO: timeout
     // TODO: tracing information
@@ -50,6 +63,14 @@ exception CannotRecordInteractionsError {
 exception RemoteServiceError {
     1: required byte code
     2: required string message
+}
+
+/**
+ * Raised when both, hostPort and knownPeers were empty so the system couldn't
+ * make a request.
+ */
+exception NoPeersAvailableError {
+    1: required string message
 }
 
 /**
@@ -80,7 +101,8 @@ service VCRProxy {
          * current cassette disallows recording new interactions.
          */
         1: CannotRecordInteractionsError cannotRecord,
-        2: RemoteServiceError remoteServiceError
-        3: VCRServiceError serviceError
+        2: RemoteServiceError remoteServiceError,
+        3: VCRServiceError serviceError,
+        4: NoPeersAvailableError noPeersAvailable,
     );
 }

--- a/tchannel/testing/vcr/proxy/VCRProxy.py
+++ b/tchannel/testing/vcr/proxy/VCRProxy.py
@@ -134,6 +134,8 @@ class Client(Iface):
       raise result.remoteServiceError
     if result.serviceError is not None:
       raise result.serviceError
+    if result.noPeersAvailable is not None:
+      raise result.noPeersAvailable
     raise TApplicationException(TApplicationException.MISSING_RESULT, "send failed: unknown result");
 
 
@@ -171,6 +173,8 @@ class Processor(Iface, TProcessor):
       result.remoteServiceError = remoteServiceError
     except VCRServiceError, serviceError:
       result.serviceError = serviceError
+    except NoPeersAvailableError, noPeersAvailable:
+      result.noPeersAvailable = noPeersAvailable
     oprot.writeMessageBegin("send", TMessageType.REPLY, seqid)
     result.write(oprot)
     oprot.writeMessageEnd()
@@ -211,6 +215,7 @@ class send_result(VCRThriftBase):
   current cassette disallows recording new interactions.
    - remoteServiceError
    - serviceError
+   - noPeersAvailable
   """
 
   __slots__ = [ 
@@ -218,6 +223,7 @@ class send_result(VCRThriftBase):
     'cannotRecord',
     'remoteServiceError',
     'serviceError',
+    'noPeersAvailable',
    ]
 
   thrift_spec = (
@@ -225,13 +231,15 @@ class send_result(VCRThriftBase):
     (1, TType.STRUCT, 'cannotRecord', (CannotRecordInteractionsError, CannotRecordInteractionsError.thrift_spec), None, ), # 1
     (2, TType.STRUCT, 'remoteServiceError', (RemoteServiceError, RemoteServiceError.thrift_spec), None, ), # 2
     (3, TType.STRUCT, 'serviceError', (VCRServiceError, VCRServiceError.thrift_spec), None, ), # 3
+    (4, TType.STRUCT, 'noPeersAvailable', (NoPeersAvailableError, NoPeersAvailableError.thrift_spec), None, ), # 4
   )
 
-  def __init__(self, success=None, cannotRecord=None, remoteServiceError=None, serviceError=None,):
+  def __init__(self, success=None, cannotRecord=None, remoteServiceError=None, serviceError=None, noPeersAvailable=None,):
     self.success = success
     self.cannotRecord = cannotRecord
     self.remoteServiceError = remoteServiceError
     self.serviceError = serviceError
+    self.noPeersAvailable = noPeersAvailable
 
   def __hash__(self):
     value = 17
@@ -239,5 +247,6 @@ class send_result(VCRThriftBase):
     value = (value * 31) ^ hash(self.cannotRecord)
     value = (value * 31) ^ hash(self.remoteServiceError)
     value = (value * 31) ^ hash(self.serviceError)
+    value = (value * 31) ^ hash(self.noPeersAvailable)
     return value
 

--- a/tchannel/thrift/server.py
+++ b/tchannel/thrift/server.py
@@ -109,7 +109,6 @@ def build_handler(result_type, f):
 
         try:
             response = yield gen.maybe_future(f(request))
-
         except Exception:
             result.write_exc_info(sys.exc_info())
         else:

--- a/tests/testing/vcr/integration/test_sync_client.py
+++ b/tests/testing/vcr/integration/test_sync_client.py
@@ -61,6 +61,65 @@ def test_record_success(tmpdir, mock_server):
 
 
 @pytest.mark.gen_test
+def test_record_success_no_hostport(tmpdir, mock_server):
+    path = tmpdir.join('data.yaml')
+    mock_server.expect_call('hello').and_write('world').once()
+    client = TChannel('test', known_peers=[mock_server.hostport])
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+        ).result(timeout=1)
+
+        assert 'world' == response.body
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+        ).result(timeout=1)
+        assert 'world' == response.body
+
+    assert cass.play_count == 1
+
+
+@pytest.mark.gen_test
+def test_record_success_no_hostport_new_channels(tmpdir, mock_server):
+    path = tmpdir.join('data.yaml')
+    mock_server.expect_call('hello').and_write('world').once()
+
+    with vcr.use_cassette(str(path)) as cass:
+        client = TChannel('test', known_peers=[mock_server.hostport])
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+        ).result(timeout=1)
+
+        assert 'world' == response.body
+
+    assert cass.play_count == 0
+    assert path.check(file=True)
+
+    with vcr.use_cassette(str(path)) as cass:
+        client = TChannel('test', known_peers=[mock_server.hostport])
+        response = client.raw(
+            'hello_service',
+            'hello',
+            'world',
+        ).result(timeout=1)
+        assert 'world' == response.body
+
+    assert cass.play_count == 1
+
+
+@pytest.mark.gen_test
 def test_record_success_new_channels(tmpdir, mock_server):
     path = tmpdir.join('data.yaml')
     mock_server.expect_call(


### PR DESCRIPTION
Previously, if hostPort wasn't specified, the VCR proxy service would end up
making a request back to the peer which made the request and that would fail
because that peer doesn't know how to respond to that request. The fix
involves tracking the known peers of a TChannel at the time the request was
made and sending it to the VCR proxy service.

Actually resolves #138.

CC @blampe @breerly @junchaowu 