### PR TITLE
add thrift support to tcurl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changes by Version
 ==================
 
-0.17.2 (unreleased)
+0.18.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Added Thrift support to ``tcurl.py`` and re-worked the script's arguments.
 
 
 0.17.1 (2015-09-17)

--- a/tchannel/tcurl.py
+++ b/tchannel/tcurl.py
@@ -131,19 +131,19 @@ def parse_args(args=None):
     )
 
     parser.add_argument(
-        "-v", "--verbose",
-        dest="verbose",
-        action="store_true",
-        help="Say more.",
-    )
-
-    parser.add_argument(
         "--health",
         action="store_true",
         help=(
             "Perform a health check against the given service. This is "
             "overridden if --endpoint is provided."
         ),
+    )
+
+    parser.add_argument(
+        "-v", "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Say more.",
     )
 
     thrift_group = parser.add_argument_group('thrift')
@@ -212,6 +212,7 @@ def main(argv=None):
     tchannel = TChannel(name='tcurl.py')
 
     if args.health:
+
         args.thrift = open(
             os.path.join(os.path.dirname(__file__), 'health/meta.thrift'),
             'r',
@@ -219,6 +220,7 @@ def main(argv=None):
         args.endpoint = "Meta::health"
 
     if args.thrift:
+
         thrift_service_name, thrift_method_name = args.endpoint.split('::')
 
         thrift_module = thrift.load(

--- a/tchannel/tcurl.py
+++ b/tchannel/tcurl.py
@@ -105,7 +105,8 @@ def parse_args(args=None):
         dest="headers",
         default=None,
         help=(
-            ", e.g., --headers foo=bar zip=zap."
+            "A JSON blob unless --raw was specified, e.g., --headers "
+            "'{\"foo\": \"bar\"}'."
         ),
     )
 
@@ -152,11 +153,11 @@ def parse_args(args=None):
         dest="thrift",
         type=argparse.FileType('r'),
         help=(
-            "Path to a Thrift IDL file. Incompatible with --json."
+            "Path to a Thrift IDL file. Incompatible with --raw."
         ),
     )
 
-    raw_group = parser.add_argument_group('json')
+    raw_group = parser.add_argument_group('raw')
 
     raw_group.add_argument(
         "--raw",

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -519,7 +519,7 @@ class PeerClientOperation(object):
         # peer, we throw exceptions from retry not NoAvailablePeerError.
         peer = self._choose()
         if not peer:
-            raise NoAvailablePeerError("Can't find available peer.")
+            raise NoAvailablePeerError("Can't find available peer for " + self.service)
         connection = yield peer.connect()
 
         arg1, arg2, arg3 = (

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -519,7 +519,9 @@ class PeerClientOperation(object):
         # peer, we throw exceptions from retry not NoAvailablePeerError.
         peer = self._choose()
         if not peer:
-            raise NoAvailablePeerError("Can't find available peer for " + self.service)
+            raise NoAvailablePeerError(
+                "Can't find available peer for " + self.service
+            )
         connection = yield peer.connect()
 
         arg1, arg2, arg3 = (

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -92,6 +92,7 @@ def test_tcurl(mock_server):
         '--host', hostport,
         '--endpoint', endpoint,
         '--service', 'mock-server',
+        '--raw',
     ])
 
     assert response.headers == endpoint

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -87,19 +87,13 @@ def test_tcurl(mock_server):
         body="hello"
     )
 
-    hostport = 'localhost:%d/%s' % (
-        mock_server.port, endpoint.decode('ascii')
+    hostport = 'localhost:%d' % mock_server.port
+    response = yield tcurl.main(
+        ['--host', hostport, '--endpoint', endpoint, '--service', 'mock-server']
     )
-    responses = yield tcurl.main(['--host', hostport, '-d', ''])
 
-    # TODO: get multiple requests working here
-    assert len(responses) == 1
-
-    for response in responses:
-        header = yield response.get_header()
-        body = yield response.get_body()
-        assert header == endpoint
-        assert body == "hello"
+    assert response.headers == endpoint
+    assert response.body == "hello"
 
 
 @pytest.mark.gen_test

--- a/tests/integration/test_client_server.py
+++ b/tests/integration/test_client_server.py
@@ -88,9 +88,11 @@ def test_tcurl(mock_server):
     )
 
     hostport = 'localhost:%d' % mock_server.port
-    response = yield tcurl.main(
-        ['--host', hostport, '--endpoint', endpoint, '--service', 'mock-server']
-    )
+    response = yield tcurl.main([
+        '--host', hostport,
+        '--endpoint', endpoint,
+        '--service', 'mock-server',
+    ])
 
     assert response.headers == endpoint
     assert response.body == "hello"

--- a/tests/test_tcurl.py
+++ b/tests/test_tcurl.py
@@ -38,14 +38,12 @@ from tchannel.testing.data.generated.ThriftTest import ThriftTest
             '-s', 'larry',
             '--headers', '{"req": "header"}',
             '--body', '{"req": "body"}',
-            '--json',
             '--endpoint', 'foo',
         ],
         dict(
             host='localhost:54496',
             headers={'req': 'header'},
             body={"req": "body"},
-            json=True,
         )
     ),
     (
@@ -58,6 +56,20 @@ from tchannel.testing.data.generated.ThriftTest import ThriftTest
             service="larry",
             thrift=mock.ANY,
             endpoint='foo::bar',
+        ),
+    ),
+    (
+        [
+            '-p', 'localhost:54496',
+            '-s', 'larry',
+            '--headers', '{"req": "header"}',
+            '--body', '{"req": "body"',
+            '--raw',
+        ],
+        dict(
+            service="larry",
+            headers='{"req": "header"}',
+            body='{"req": "body"',
         ),
     ),
 ])
@@ -109,18 +121,7 @@ def test_parse_valid_args(input, expectations):
             '-p', 'localhost:54496',
             '-s', 'larry',
             '--headers', '{"req": "header"}',
-            '--body', '{"req": "body"}',
-            '--json',
-        ],
-        '--json must be used with --endpoint',
-    ),
-    (
-        [
-            '-p', 'localhost:54496',
-            '-s', 'larry',
-            '--headers', '{"req": "header"}',
             '--body', '{"req": "body"',
-            '--json',
         ],
         "--body isn't valid JSON",
     ),
@@ -186,7 +187,6 @@ def test_tcurl_json():
         '--host', server.hostport,
         '--body', '{"thing": "foo"}',
         '--endpoint', 'test',
-        '--json',
     ])
 
     assert response.body == {"thing": "foo"}

--- a/tests/test_tcurl.py
+++ b/tests/test_tcurl.py
@@ -25,7 +25,7 @@ import tornado.gen
 import pytest
 
 from tchannel import TChannel
-from tchannel.tcurl import catch_errors
+from tchannel.tcurl import _catch_errors
 from tchannel.tcurl import main
 from tchannel.tcurl import parse_args
 from tchannel.testing.data.generated.ThriftTest import ThriftTest
@@ -125,6 +125,24 @@ def test_parse_valid_args(input, expectations):
         ],
         "--body isn't valid JSON",
     ),
+    (
+        [
+            '-p', 'localhost:54496',
+            '-s', 'larry',
+            '--headers', '{"req": "header"',
+            '--body', '{"req": "body"}',
+        ],
+        "--headers isn't valid JSON",
+    ),
+    (
+        [
+            '--service', 'larry',
+            '--thrift', 'tests/data/idls/ThriftTest.thrift',
+            '--endpoint', 'foo::bar',
+            '--raw',
+        ],
+        "can't use --thrift and --raw together",
+    ),
 ])
 def test_parse_invalid_args(input, message, capsys):
     with pytest.raises(SystemExit) as e:
@@ -205,7 +223,7 @@ def test_catch_errors(capsys):
     f.set_exception(Exception("Foobar"))
 
     with pytest.raises(Exit):
-        yield catch_errors(f, verbose=False, exit=exit)
+        yield _catch_errors(f, verbose=False, exit=exit)
 
     out, err = capsys.readouterr()
 
@@ -225,7 +243,7 @@ def test_catch_errors_verbose(capsys):
     f.set_exception(Exception("Foobar"))
 
     with pytest.raises(Exit):
-        yield catch_errors(f, verbose=True, exit=exit)
+        yield _catch_errors(f, verbose=True, exit=exit)
 
     out, err = capsys.readouterr()
 

--- a/tests/test_tcurl.py
+++ b/tests/test_tcurl.py
@@ -20,32 +20,69 @@
 
 from __future__ import absolute_import
 
+import collections
+
+import mock
 import pytest
 
 from tchannel.tcurl import parse_args
 
 
-@pytest.mark.parametrize('input,expected', [
+Expectation = collections.namedtuple(
+    'Expectation',
+    'host, service, headers, endpoint, body, thrift, json',
+)
+
+
+@pytest.mark.parametrize('input, expectations', [
     (   # basic case
-        '--host foo --profile',
-        [['foo/'], [None], [None], True]
+        ['-p', 'localhost:54496', '-s', 'larry', '--headers', '{"req": "header"}', '--body', '{"req": "body"}', '--json', '--endpoint', 'foo'],
+        dict(host='localhost:54496', headers={'req': 'header'}, body={"req": "body"}, json=True)
     ),
-    (   # multiple bodies, constant host/headers
-        '--host foo -d 1 2',
-        [['foo/', 'foo/'], ['1', '2'], [None, None], False]
-    ),
-    (   # repeated host and body
-        '--host foo bar -d 1 2',
-        [['foo/', 'bar/'], ['1', '2'], [None, None], False]
-    ),
-    (   # repeated host and body
-        '--host foo -d 1 --headers a b',
-        [['foo/', 'foo/'], ['1', '1'], ['a', 'b'], False]
+    (
+        ['--service', 'larry', '--thrift', 'tests/data/idls/ThriftTest.thrift', '--endpoint', 'foo::bar'],
+        dict(service="larry", thrift=mock.ANY, endpoint='foo::bar'),
     ),
 ])
-def test_parse_args(input, expected):
-    args = parse_args(input.split())
-    assert list(args.host) == expected[0]
-    assert list(args.body) == expected[1]
-    assert list(args.headers) == expected[2]
-    assert args.profile == expected[3]
+def test_parse_valid_args(input, expectations):
+    args = parse_args(input)
+
+    for key, expected in expectations.iteritems():
+        assert expected == getattr(args, key)
+
+
+@pytest.mark.parametrize('input, message', [
+    (
+        [''],
+        'argument --service/-s is required'
+    ),
+    (
+        ['--service', 'larry', '--thrift'],
+        '--thrift/-t: expected one argument',
+    ),
+    (
+        ['--service', 'larry', '--thrift', 'foo.thrift'],
+        'No such file or directory',
+    ),
+    (
+        ['--service', 'larry', '--thrift', 'tests/data/idls/ThriftTest.thrift', '--endpoint'],
+        '--endpoint/-1: expected one argument',
+    ),
+    (
+        ['--service', 'larry', '--thrift', 'tests/data/idls/ThriftTest.thrift', '--endpoint', 'foo'],
+        '--endpoint should be of the form'
+    ),
+    (
+        ['-p', 'localhost:54496', '-s', 'larry', '--headers', '{"req": "header"}', '--body', '{"req": "body"}', '--json'],
+        '--json must be used with --endpoint',
+    )
+])
+def test_parse_invalid_args(input, message, capsys):
+    with pytest.raises(SystemExit) as e:
+        parse_args(input)
+
+    # Arg parse always dies with an error code of 2.
+    assert e.value.message == 2
+
+    out, err = capsys.readouterr()
+    assert message in err


### PR DESCRIPTION
Shooting to landing this in the 0.18 branch. Resolves #6.

- Thrift support
- 100% test coverage
- Args more closely match tcurl.js
- Errors only surface as tracebacks with `-v`

@breerly @junchaowu 

```
$ tcurl.py -h
usage: tcurl.py [-h] --service SERVICE [--host HOST] [--endpoint ENDPOINT]
                [--headers HEADERS] [--body BODY] [--timeout TIMEOUT]
                [--health] [-v] [--thrift THRIFT] [--raw]

tcurl: curl for tchannel applications

examples:

    Health check the "larry" service:

      tcurl.py --health --service larry

    Send a Thrift request to "larry":

      tcurl.py --thrift larry.thrift --service larry --endpoint Larry::nyuck \
      --body '{"nyuck": "nyuck"}'

optional arguments:
  -h, --help            show this help message and exit
  --service SERVICE, -s SERVICE
                        Name of destination service for Hyperbahn routing.
                        (default: None)
  --host HOST, -p HOST  Hostname and port to contact. (default:
                        localhost:21300)
  --endpoint ENDPOINT, -1 ENDPOINT
                        Name of destination service for Hyperbahn routing.
                        (default: )
  --headers HEADERS, -2 HEADERS
                        A JSON blob unless --raw was specified, e.g.,
                        --headers '{"foo": "bar"}'. (default: None)
  --body BODY, -3 BODY  A JSON blob unless --raw was specified. This is
                        coerced into a Thrift structure when --thrift is
                        given. (default: None)
  --timeout TIMEOUT     Timeout, in seconds, for the request. (default: 1.0)
  --health              Perform a health check against the given service. This
                        overrides --endpoint. (default: False)
  -v, --verbose         Say more. (default: False)

thrift:
  --thrift THRIFT, -t THRIFT
                        Path to a Thrift IDL file. Incompatible with --raw.
                        (default: None)

raw:
  --raw                 Treats --body as a binary blob instead of JSON.
                        (default: False)
```