### PR TITLE
add some debugging info to no-peer error

### DIFF
--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -519,7 +519,10 @@ class PeerClientOperation(object):
         # peer, we throw exceptions from retry not NoAvailablePeerError.
         peer = self._choose()
         if not peer:
-            raise NoAvailablePeerError("Can't find available peer.")
+            raise NoAvailablePeerError(
+                "Can't find an available peer for '%s'" % self.service
+            )
+
         connection = yield peer.connect()
 
         arg1, arg2, arg3 = (


### PR DESCRIPTION
It doesn't tell you the peer it was trying to find, which is unhelpful.

@junchaowu @breerly 