### PR TITLE
use add_future instead of add_done_callback to help with interleaving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes by Version
 0.17.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed uses of ``add_done_callback`` that should have been ``add_future``.
+  This was preventing propper request/response interleaving.
 
 
 0.17.2 (2015-09-18)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -182,9 +182,12 @@ class TornadoConnection(object):
             size_bytes = read_size_future.result()
             size = frame.frame_rw.size_rw.read(BytesIO(size_bytes))
             read_body_future = self.connection.read_bytes(size - size_width)
-            read_body_future.add_done_callback(
+
+            tornado.ioloop.IOLoop.current().add_future(
+                read_body_future,
                 lambda future: on_body(future, size)
             )
+
             return read_body_future
 
         def on_error(future):
@@ -194,7 +197,12 @@ class TornadoConnection(object):
                 self.close()
 
         size_width = frame.frame_rw.size_rw.width()
-        self.connection.read_bytes(size_width).add_done_callback(on_read_size)
+        read_bytes_future = self.connection.read_bytes(size_width)
+
+        tornado.ioloop.IOLoop.current().add_future(
+            read_bytes_future,
+            on_read_size,
+        )
 
         return message_future
 
@@ -577,8 +585,9 @@ class StreamConnection(TornadoConnection):
 
         stream_future = self._stream(request, self.request_message_factory)
 
-        stream_future.add_done_callback(
-            lambda f: request.close_argstreams(force=True),
+        tornado.ioloop.IOLoop.current().add_future(
+            stream_future,
+            lambda f: request.close_argstreams(force=True)
         )
 
         return stream_future

--- a/tchannel/tornado/stream.py
+++ b/tchannel/tornado/stream.py
@@ -140,7 +140,8 @@ class InMemStream(Stream):
         # We're not ready yet
         if self.state != StreamState.completed and not len(self._stream):
             wait_future = self._condition.wait()
-            wait_future.add_done_callback(
+            tornado.ioloop.IOLoop.current().add_future(
+                wait_future,
                 lambda f: f.exception() or read_chunk(read_future)
             )
             return read_future

--- a/tchannel/tornado/util.py
+++ b/tchannel/tornado/util.py
@@ -85,7 +85,7 @@ def chain(iterable, func):
         except StopIteration:
             all_done_future.set_result(None)
         else:
-            func(arg).add_done_callback(handle)
+            tornado.ioloop.IOLoop.current().add_future(func(arg), handle)
 
     go()
 


### PR DESCRIPTION
Resolves #188.

```
got resp foo 1010.86401939
got resp foo 2018.96500587
got resp foo 3020.56193352
got resp foo 4025.67911148
got resp foo 5029.83212471
got resp foo 6035.28594971
got resp foo 7041.84007645
got resp foo 8048.09808731
got resp foo 9052.15597153
got resp foo 10054.5840263
```

From the Tornado docs:
> In Tornado consider using IOLoop.add_future instead of calling add_done_callback directly.

Seems that ``add_done_callback`` will preemptively schedule callbacks whereas ``add_futures`` adds them to the end of the queue.

@breerly @junchaowu @torwegia @cheeuber