### PR TITLE
Make message_factory stateless

### DIFF
--- a/tchannel/testing/vcr/patch.py
+++ b/tchannel/testing/vcr/patch.py
@@ -85,7 +85,7 @@ class PatchedClientOperation(object):
         vcr_request = proxy.Request(
             serviceName=self.service.encode('utf-8'),
             hostPort=self.hostport,
-            knownPeers=self.original_tchannel.peers.hosts,
+            knownPeers=self.original_tchannel.peer_group.hosts,
             endpoint=endpoint,
             headers=(yield read_full(arg2)),
             body=(yield read_full(arg3)),

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -32,8 +32,8 @@ from .. import errors
 from .. import frame
 from .. import glossary
 from .. import messages
-from ..errors import NetworkError
 from ..errors import FatalProtocolError
+from ..errors import NetworkError
 from ..errors import TChannelError
 from ..event import EventType
 from ..io import BytesIO
@@ -103,12 +103,9 @@ class TornadoConnection(object):
         # Tracks message IDs for this connection.
         self._id_sequence = 0
 
-        # We need to use two separate message factories to avoid message ID
-        # collision while assembling fragmented messages.
-        self.request_message_factory = MessageFactory(self.remote_host,
-                                                      self.remote_host_port)
-        self.response_message_factory = MessageFactory(self.remote_host,
-                                                       self.remote_host_port)
+        self.message_factory = MessageFactory(
+            self.remote_host, self.remote_host_port
+        )
 
         # Queue of unprocessed incoming calls.
         self._messages = queues.Queue()
@@ -122,6 +119,15 @@ class TornadoConnection(object):
 
         self.tchannel = tchannel
 
+        # Map from message ID to inflight requests on the server side.
+        self.incoming_requests = {}
+        # Map from message ID to inflight responses on the client side.
+        # When client sends a request, it will first put ID and a future for
+        # response in the _outstanding map. After it gets response message,
+        # but not a completed response, it will put ID and response obj in the
+        # incoming_response.
+        self.incoming_responses = {}
+
         connection.set_close_callback(self._on_close)
 
     def next_message_id(self):
@@ -130,7 +136,6 @@ class TornadoConnection(object):
 
     def _on_close(self):
         self.closed = True
-
         for message_id, future in self._outstanding.iteritems():
             future.set_exception(
                 NetworkError(
@@ -138,7 +143,6 @@ class TornadoConnection(object):
                 )
             )
         self._outstanding = {}
-
         try:
             while True:
                 message = self._messages.get_nowait()
@@ -195,6 +199,8 @@ class TornadoConnection(object):
 
             if isinstance(exception, tornado.iostream.StreamClosedError):
                 self.close()
+            if message_future.running():
+                message_future.set_exception(exception)
 
         size_width = frame.frame_rw.size_rw.width()
         read_bytes_future = self.connection.read_bytes(size_width)
@@ -213,50 +219,64 @@ class TornadoConnection(object):
         #
         # Must be started only after the handshake has been performed.
         self._loop_running = True
+
         while not self.closed:
-            message = yield self._recv()
-            # TODO: There should probably be a try-catch on the yield.
+            try:
+                message = yield self._recv()
+            except tornado.iostream.StreamClosedError:
+                log.warning("Stream has been closed.")
+                break
+
             if message.message_type in self.CALL_REQ_TYPES:
                 self._messages.put(message)
-                continue
-
             elif message.id in self._outstanding:
-                # set exception if receive error message
-                if message.message_type == Types.ERROR:
-                    future = self._outstanding.pop(message.id)
-                    if future.running():
-                        error = TChannelError.from_code(
-                            message.code,
-                            description=message.description,
-                        )
-                        future.set_exception(error)
-                    else:
-                        protocol_exception = (
-                            self.response_message_factory.build(message)
-                        )
-                        if protocol_exception:
-                            self.event_emitter.fire(
-                                EventType.after_receive_error,
-                                protocol_exception,
-                            )
-                    continue
+                # This should just handle CALL_RES or ERROR message.
+                # It is invalid if any CALL_RES_CONTINUE message goes here.
+                self._handle_response(message)
+            elif message.id in self.incoming_responses:
+                # This should just handle CALL_RES_CONTINUE or ERROR message.
+                # It is invalid if any CALL_RES message goes here.
+                self._handle_continuing_response(message)
+            else:
+                log.warn('Unconsumed message %s', message)
 
-                response = self.response_message_factory.build(message)
+    def _handle_continuing_response(self, message):
+        response = self.incoming_responses.pop(message.id)
+        if message.message_type == Types.ERROR:
+            error = self.message_factory.build_inbound_error(message)
+            response.set_exception(error)
 
-                # keep continue message in the list
-                # pop all other type messages including error message
-                if (message.message_type in self.CALL_RES_TYPES and
-                        message.flags == FlagsType.fragment):
-                    # still streaming, keep it for record
-                    future = self._outstanding.get(message.id)
-                else:
-                    future = self._outstanding.pop(message.id)
+            self.tchannel.event_emitter.fire(
+                EventType.after_receive_error, error,
+            )
+            return
 
-                if response and future.running():
-                    future.set_result(response)
-                continue
+        self.message_factory.build_inbound_response(message, response)
 
-            log.warn('Unconsumed message %s', message)
+        if (message.message_type in self.CALL_RES_TYPES and
+                message.flags == FlagsType.fragment):
+            # still streaming, keep it for record
+            self.incoming_responses[message.id] = response
+
+    def _handle_response(self, message):
+        future = self._outstanding.pop(message.id)
+        if message.message_type == Types.ERROR:
+            error = self.message_factory.build_inbound_error(message)
+            if future.running():
+                future.set_exception(error)
+
+            self.tchannel.event_emitter.fire(
+                EventType.after_receive_error, error,
+            )
+            return
+
+        response = self.message_factory.build_inbound_response(message, None)
+        if future.running():
+            future.set_result(response)
+        if (message.message_type in self.CALL_RES_TYPES and
+                message.flags == FlagsType.fragment):
+            # still streaming, keep it for record
+            self.incoming_responses[message.id] = response
 
     # Basically, the only difference between send and write is that send
     # sets up a Future to get the response. That's ideal for peers making
@@ -298,12 +318,7 @@ class TornadoConnection(object):
 
         message.id = message.id or self.next_message_id()
 
-        if message.message_type in self.CALL_REQ_TYPES:
-            message_factory = self.request_message_factory
-        else:
-            message_factory = self.response_message_factory
-
-        fragments = message_factory.fragment(message)
+        fragments = self.message_factory.fragment(message)
 
         return chain(fragments, self._write)
 
@@ -460,10 +475,8 @@ class TornadoConnection(object):
         """
         assert handler, "handler is required"
         assert self._loop_running, "Finish the handshake first"
-
         while not self.closed:
             message = yield self.await()
-
             try:
                 handler(message, self)
             except Exception:
@@ -496,6 +509,16 @@ class TornadoConnection(object):
 
     def pong(self):
         return self._write(messages.PingResponseMessage())
+
+    def add_incoming_request(self, request):
+        self.incoming_requests[request.id] = request
+
+    def get_incoming_request(self, id):
+        return self.incoming_requests.get(id, None)
+
+    def remove_incoming_request(self, id):
+        req = self.incoming_requests.pop(id, None)
+        return req
 
 
 class StreamConnection(TornadoConnection):
@@ -569,7 +592,7 @@ class StreamConnection(TornadoConnection):
     def post_response(self, response):
         try:
             # TODO: before_send_response
-            yield self._stream(response, self.response_message_factory)
+            yield self._stream(response, self.message_factory)
 
             # event: send_response
             self.tchannel.event_emitter.fire(
@@ -583,7 +606,7 @@ class StreamConnection(TornadoConnection):
         """send the given request and response is not required"""
         request.close_argstreams()
 
-        stream_future = self._stream(request, self.request_message_factory)
+        stream_future = self._stream(request, self.message_factory)
 
         tornado.ioloop.IOLoop.current().add_future(
             stream_future,

--- a/tchannel/tornado/hyperbahn.py
+++ b/tchannel/tornado/hyperbahn.py
@@ -123,7 +123,7 @@ def advertise(tchannel, service, routers=None, timeout=None, router_file=None):
     for router in routers:
         # We use .get here instead of .add because we don't want to fail if a
         # TChannel already knows about some of the routers.
-        tchannel.peers.get(router)
+        tchannel.peer_group.get(router)
 
     result = yield _advertise_with_backoff(
         tchannel, service, timeout=timeout

--- a/tchannel/tornado/message_factory.py
+++ b/tchannel/tornado/message_factory.py
@@ -22,8 +22,8 @@ from __future__ import absolute_import
 
 import logging
 
-from ..errors import InvalidChecksumError
 from ..errors import FatalProtocolError
+from ..errors import InvalidChecksumError
 from ..errors import TChannelError
 from ..messages import RW
 from ..messages import Types
@@ -33,7 +33,6 @@ from ..messages.call_request import CallRequestMessage
 from ..messages.call_request_continue import CallRequestContinueMessage
 from ..messages.call_response import CallResponseMessage
 from ..messages.call_response_continue import CallResponseContinueMessage
-from ..messages.common import CHECKSUM_MSG_TYPES
 from ..messages.common import FlagsType
 from ..messages.common import StreamState
 from ..messages.common import Tracing
@@ -64,390 +63,377 @@ def build_raw_error_message(protocol_exception):
     return message
 
 
-class MessageFactory(object):
-    """Provide the functionality to decompose and recompose
-    streaming messages.
+def build_raw_request_message(request, args, is_completed=False):
+    """build protocol level message based on request and args.
+
+    request object contains meta information about outgoing request.
+    args are the currently chunk data from argstreams
+    is_completed tells the flags of the message
+
+    :param request: Request
+    :param args: array of arg streams
+    :param is_completed: flag to tell whether the request is completed or not
+    :return: CallRequestMessage/CallRequestContinueMessage
+    """
+    request.flags = FlagsType.none if is_completed else FlagsType.fragment
+
+    # TODO decide what need to pass from request
+    if request.state == StreamState.init:
+        message = CallRequestMessage(
+            id=request.id,
+            flags=request.flags,
+            ttl=request.ttl * 1000,
+            tracing=Tracing(request.tracing.span_id,
+                            request.tracing.parent_span_id,
+                            request.tracing.trace_id,
+                            request.tracing.traceflags),
+            service=request.service,
+            headers=request.headers,
+            checksum=request.checksum,
+            args=args,
+        )
+        request.state = (StreamState.completed if is_completed
+                         else StreamState.streaming)
+    elif request.state == StreamState.streaming:
+        message = CallRequestContinueMessage(
+            id=request.id,
+            flags=request.flags,
+            checksum=request.checksum,
+            args=args,
+        )
+        request.state = (StreamState.completed if is_completed
+                         else StreamState.streaming)
+
+    message.id = request.id
+    return message
+
+
+def build_raw_response_message(response, args, is_completed=False):
+    """build protocol level message based on response and args.
+
+    response object contains meta information about outgoing response.
+    args are the currently chunk data from argstreams
+    is_completed tells the flags of the message
+
+    :param response: Response
+    :param args: array of arg streams
+    :param is_completed: flag to tell whether the request is completed or not
+    :return: CallResponseMessage/CallResponseContinueMessage
+    """
+    response.flags = FlagsType.none if is_completed else FlagsType.fragment
+
+    # TODO decide what need to pass from request
+    if response.state == StreamState.init:
+        message = CallResponseMessage(
+            id=response.id,
+            flags=response.flags,
+            code=response.code,
+            tracing=Tracing(response.tracing.span_id,
+                            response.tracing.parent_span_id,
+                            response.tracing.trace_id,
+                            response.tracing.traceflags),
+            headers=response.headers,
+            checksum=response.checksum,
+            args=args,
+        )
+        response.state = (StreamState.completed if is_completed
+                          else StreamState.streaming)
+    elif response.state == StreamState.streaming:
+        message = CallResponseContinueMessage(
+            id=response.id,
+            flags=response.flags,
+            checksum=response.checksum,
+            args=args,
+        )
+        response.state = (StreamState.completed if is_completed
+                          else StreamState.streaming)
+
+    message.id = response.id
+    return message
+
+
+def build_raw_message(reqres, args, is_completed=False):
+    if isinstance(reqres, Request):
+        return build_raw_request_message(reqres, args, is_completed)
+    elif isinstance(reqres, Response):
+        return build_raw_response_message(reqres, args, is_completed)
+
+
+def prepare_args(message):
+    args = [
+        InMemStream(auto_close=False),
+        InMemStream(auto_close=False),
+        InMemStream(auto_close=False),
+    ]
+    for i, arg in enumerate(message.args):
+        if i > 0:
+            args[i - 1].close()
+        args[i].write(arg)
+
+    return args
+
+
+def build_request(message, remote_host=None, remote_host_port=None):
+    """Build request object from protocol level message info
+
+    It is allowed to take incomplete CallRequestMessage. Therefore the
+    created request may not contain whole three arguments.
+
+    :param message: CallRequestMessage
+    :param remote_host: remote host IP
+    :param remote_host_port: remote host port
+    :return: request object
     """
 
-    def __init__(self, remote_host=None, remote_host_port=None):
-        self.remote_host = remote_host
-        self.remote_host_port = remote_host_port
+    args = prepare_args(message)
 
-        self.in_checksum = {}
-        self.out_checksum = {}
+    tracing = Trace(
+        trace_id=message.tracing.trace_id,
+        span_id=message.tracing.span_id,
+        parent_span_id=message.tracing.parent_id,
+        endpoint=Endpoint(remote_host,
+                          remote_host_port,
+                          message.service),
+        traceflags=message.tracing.traceflags
+    )
 
-    def build_raw_request_message(self, request, args, is_completed=False):
-        """build protocol level message based on request and args.
+    # TODO decide what to pass to Request from message
+    req = Request(
+        flags=message.flags,
+        ttl=message.ttl / 1000.0,
+        tracing=tracing,
+        service=message.service,
+        headers=message.headers,
+        checksum=message.checksum,
+        argstreams=args,
+        id=message.id,
+    )
+    return req
 
-        request object contains meta information about outgoing request.
-        args are the currently chunk data from argstreams
-        is_completed tells the flags of the message
 
-        :param request: Request
-        :param args: array of arg streams
-        :param is_completed: message flags
-        :return: CallRequestMessage/CallRequestContinueMessage
-        """
-        request.flags = FlagsType.none if is_completed else FlagsType.fragment
+def build_response(message):
+    """Build response object from protocol level message info
 
-        # TODO decide what need to pass from request
-        if request.state == StreamState.init:
-            message = CallRequestMessage(
-                flags=request.flags,
-                ttl=request.ttl * 1000,
-                tracing=Tracing(request.tracing.span_id,
-                                request.tracing.parent_span_id,
-                                request.tracing.trace_id,
-                                request.tracing.traceflags),
-                service=request.service,
-                headers=request.headers,
-                checksum=request.checksum,
-                args=args
-            )
-            request.state = (StreamState.completed if is_completed
-                             else StreamState.streaming)
-        elif request.state == StreamState.streaming:
-            message = CallRequestContinueMessage(
-                flags=request.flags,
-                checksum=request.checksum,
-                args=args
-            )
-            request.state = (StreamState.completed if is_completed
-                             else StreamState.streaming)
+    It is allowed to take incomplete CallResponseMessage. Therefore the
+    created request may not contain whole three arguments.
 
-        message.id = request.id
-        return message
+    :param message: CallResponseMessage
+    :return: response object
+    """
 
-    def build_raw_response_message(self, response, args, is_completed=False):
-        """build protocol level message based on response and args.
+    args = prepare_args(message)
 
-        response object contains meta information about outgoing response.
-        args are the currently chunk data from argstreams
-        is_completed tells the flags of the message
+    # TODO decide what to pass to Response from message
+    res = Response(
+        flags=message.flags,
+        code=message.code,
+        headers=message.headers,
+        checksum=message.checksum,
+        argstreams=args,
+        id=message.id,
+    )
+    return res
 
-        :param response: Response
-        :param args: array of arg streams
-        :param is_completed: message flags
-        :return: CallResponseMessage/CallResponseContinueMessage
-        """
-        response.flags = FlagsType.none if is_completed else FlagsType.fragment
 
-        # TODO decide what need to pass from request
-        if response.state == StreamState.init:
-            message = CallResponseMessage(
-                flags=response.flags,
-                code=response.code,
-                tracing=Tracing(response.tracing.span_id,
-                                response.tracing.parent_span_id,
-                                response.tracing.trace_id,
-                                response.tracing.traceflags),
-                headers=response.headers,
-                checksum=response.checksum,
-                args=args
-            )
-            response.state = (StreamState.completed if is_completed
-                              else StreamState.streaming)
-        elif response.state == StreamState.streaming:
-            message = CallResponseContinueMessage(
-                flags=response.flags,
-                checksum=response.checksum,
-                args=args
-            )
-            response.state = (StreamState.completed if is_completed
-                              else StreamState.streaming)
+def build_inbound_response(message):
+    """Build new response based on incoming call response message.
 
-        message.id = response.id
-        return message
-
-    def build_raw_message(self, reqres, args, is_completed=False):
-        if isinstance(reqres, Request):
-            return self.build_raw_request_message(reqres, args, is_completed)
-        elif isinstance(reqres, Response):
-            return self.build_raw_response_message(reqres, args, is_completed)
-
-    def prepare_args(self, message):
-        args = [
-            InMemStream(auto_close=False),
-            InMemStream(auto_close=False),
-            InMemStream(auto_close=False),
-        ]
-        for i, arg in enumerate(message.args):
-            if i > 0:
-                args[i - 1].close()
-            args[i].write(arg)
-
-        return args
-
-    def build_request(self, message):
-        """Build request object from protocol level message info
-
-        It is allowed to take incomplete CallRequestMessage. Therefore the
-        created request may not contain whole three arguments.
-
-        :param message: CallRequestMessage
-        :return: request object
-        """
-
-        args = self.prepare_args(message)
-
-        tracing = Trace(
-            trace_id=message.tracing.trace_id,
-            span_id=message.tracing.span_id,
-            parent_span_id=message.tracing.parent_id,
-            endpoint=Endpoint(self.remote_host,
-                              self.remote_host_port,
-                              message.service),
-            traceflags=message.tracing.traceflags
+    :param message:
+        Incoming call response message message.
+    :return:
+        New response object.
+    """
+    if message.message_type != Types.CALL_RES:
+        raise FatalProtocolError(
+            "Receiving unexpected message type %d for message ID %d" %
+            (message.message_type, message.id)
         )
 
-        # TODO decide what to pass to Request from message
-        req = Request(
-            flags=message.flags,
-            ttl=message.ttl / 1000.0,
-            tracing=tracing,
-            service=message.service,
-            headers=message.headers,
-            checksum=message.checksum,
-            argstreams=args,
-            id=message.id,
-        )
-        return req
+    if not verify_checksum(message, 0):
+        raise InvalidChecksumError("Checksum does not match!")
+    response = build_response(message)
+    num = _find_incomplete_stream(response)
+    close_argstream(response, num)
+    return response
 
-    def build_response(self, message):
-        """Build response object from protocol level message info
 
-        It is allowed to take incomplete CallResponseMessage. Therefore the
-        created request may not contain whole three arguments.
+def build_inbound_response_cont(message, response):
+    """Add incoming call response continue message's data into
+    corresponding pending response object.
 
-        :param message: CallResponseMessage
-        :return: response object
-        """
-
-        args = self.prepare_args(message)
-
-        # TODO decide what to pass to Response from message
-        res = Response(
-            flags=message.flags,
-            code=message.code,
-            headers=message.headers,
-            checksum=message.checksum,
-            argstreams=args,
-            id=message.id,
-        )
-        return res
-
-    def build_inbound_response(self, message):
-        """Build new response based on incoming call response message.
-
-        :param message:
-            Incoming call response message message.
-        :return:
-            New response object.
-        """
-        if message.message_type != Types.CALL_RES:
-            raise FatalProtocolError(
-                "Receiving unexpected message type %d for message ID %d" %
-                (message.message_type, message.id)
-            )
-
-        self.verify_message(message)
-        response = self.build_response(message)
-        num = self._find_incomplete_stream(response)
-        self.close_argstream(response, num)
-        return response
-
-    def build_inbound_response_cont(self, message, response):
-        """Add incoming call response continue message's data into
-        corresponding pending response object.
-
-        :param message:
-            Incoming call response continue message.
-        :param response:
-            Corresponding pending response with same message Id.
-        """
-        if message.message_type != Types.CALL_RES_CONTINUE:
-            raise FatalProtocolError(
-                "Receiving unexpected message type %d for message ID %d" %
-                (message.message_type, message.id)
-            )
-
-        if response is None:
-            # missing call msg before continue msg
-            raise FatalProtocolError(
-                ("Received call response continuation for" +
-                 "unknown message %d" % message.id)
-            )
-
-        dst = self._find_incomplete_stream(response)
-        try:
-            self.verify_message(message)
-        except InvalidChecksumError as e:
-            response.argstreams[dst].set_exception(e)
-            raise
-
-        src = 0
-        while src < len(message.args):
-            response.argstreams[dst].write(message.args[src])
-            dst += 1
-            src += 1
-
-        if message.flags != FlagsType.fragment:
-            # get last fragment. mark it as completed
-            assert (len(response.argstreams) ==
-                    CallContinueMessage.max_args_num)
-            response.flags = FlagsType.none
-
-        self.close_argstream(response, dst - 1)
-
-    @classmethod
-    def build_inbound_error(cls, message):
-        """convert error message to TChannelError type."""
-        return TChannelError.from_code(
-            message.code,
-            description=message.description,
-            tracing=message.tracing
+    :param message:
+        Incoming call response continue message.
+    :param response:
+        Corresponding pending response with same message Id.
+    """
+    if message.message_type != Types.CALL_RES_CONTINUE:
+        raise FatalProtocolError(
+            "Receiving unexpected message type %d for message ID %d" %
+            (message.message_type, message.id)
         )
 
-    def build_inbound_request(self, message):
-        """Build inbound request based on incoming call request message.
+    if response is None:
+        # missing call msg before continue msg
+        raise FatalProtocolError(
+            ("Received call response continuation for" +
+             "unknown message %d" % message.id)
+        )
 
-        :param message:
-            Incoming call request message.
-        :return:
-            New request object.
-        """
-        if message.message_type != Types.CALL_REQ:
-            raise FatalProtocolError(
-                "Receiving unexpected message type %d for message ID %d" %
-                (message.message_type, message.id)
-            )
+    dst = _find_incomplete_stream(response)
+    if not verify_checksum(message, response.checksum[1]):
+        e = InvalidChecksumError("Checksum does not match!")
+        response.argstreams[dst].set_exception(e)
+        raise e
+    else:
+        response.checksum = message.checksum
 
-        self.verify_message(message)
-        request = self.build_request(message)
-        num = self._find_incomplete_stream(request)
-        self.close_argstream(request, num)
-        return request
+    src = 0
+    while src < len(message.args):
+        response.argstreams[dst].write(message.args[src])
+        dst += 1
+        src += 1
 
-    def build_inbound_request_cont(self, message, request):
-        """Add incoming call request continue message's data into
-        corresponding pending request object.
+    if message.flags != FlagsType.fragment:
+        # get last fragment. mark it as completed
+        assert (len(response.argstreams) ==
+                CallContinueMessage.max_args_num)
+        response.flags = FlagsType.none
 
-        :param message:
-            Incoming call request continue message.
-        :param request:
-            Corresponding pending response with same message Id.
-        """
-        if message.message_type != Types.CALL_REQ_CONTINUE:
-            raise FatalProtocolError(
-                "Receiving unexpected message type %d for message ID %d" %
-                (message.message_type, message.id)
-            )
+    close_argstream(response, dst - 1)
 
-        if request is None:
-            # missing call msg before continue msg
-            raise FatalProtocolError(
-                "missing call message after receiving continue message"
-            )
 
-        dst = self._find_incomplete_stream(request)
-        try:
-            self.verify_message(message)
-        except InvalidChecksumError as e:
-            request.argstreams[dst].set_exception(e)
-            raise
+def build_inbound_error(message):
+    """convert error message to TChannelError type."""
+    return TChannelError.from_code(
+        message.code,
+        description=message.description,
+        tracing=message.tracing
+    )
 
-        src = 0
-        while src < len(message.args):
-            request.argstreams[dst].write(message.args[src])
-            dst += 1
-            src += 1
 
-        if message.flags != FlagsType.fragment:
-            # get last fragment. mark it as completed
-            assert (len(request.argstreams) ==
-                    CallContinueMessage.max_args_num)
-            request.flags = FlagsType.none
+def build_inbound_request(message, remote_host=None, remote_host_port=None):
+    """Build inbound request based on incoming call request message.
 
-        self.close_argstream(request, dst - 1)
+    :param message:
+        Incoming call request message.
+    :param remote_host: remote host IP
+    :param remote_host_port: remote host port
+    :return:
+        New request object.
+    """
+    if message.message_type != Types.CALL_REQ:
+        raise FatalProtocolError(
+            "Receiving unexpected message type %d for message ID %d" %
+            (message.message_type, message.id)
+        )
 
-    @classmethod
-    def _find_incomplete_stream(cls, reqres):
-        # find the incomplete stream
-        num = 0
-        for i, arg in enumerate(reqres.argstreams):
-            if arg.state != StreamState.completed:
-                num = i
-                break
-        return num
+    if not verify_checksum(message, 0):
+        raise InvalidChecksumError("Checksum does not match!")
+    request = build_request(message, remote_host, remote_host_port)
+    num = _find_incomplete_stream(request)
+    close_argstream(request, num)
+    return request
 
-    def fragment(self, message):
-        """Fragment message based on max payload size
 
-        note: if the message doesn't need to fragment,
-        it will return a list which only contains original
-        message itself.
+def build_inbound_request_cont(message, request):
+    """Add incoming call request continue message's data into
+    corresponding pending request object.
 
-        :param message: raw message
-        :return: list of messages whose sizes <= max
-            payload size
-        """
-        if message.message_type in [Types.CALL_RES,
-                                    Types.CALL_REQ,
-                                    Types.CALL_REQ_CONTINUE,
-                                    Types.CALL_RES_CONTINUE]:
+    :param message:
+        Incoming call request continue message.
+    :param request:
+        Corresponding pending response with same message Id.
+    """
+    if message.message_type != Types.CALL_REQ_CONTINUE:
+        raise FatalProtocolError(
+            "Receiving unexpected message type %d for message ID %d" %
+            (message.message_type, message.id)
+        )
+
+    if request is None:
+        # missing call msg before continue msg
+        raise FatalProtocolError(
+            "missing call message after receiving continue message"
+        )
+
+    dst = _find_incomplete_stream(request)
+    if not verify_checksum(message, request.checksum[1]):
+        e = InvalidChecksumError("Checksum does not match!")
+        request.argstreams[dst].set_exception(e)
+        raise e
+    else:
+        request.checksum = message.checksum
+
+    src = 0
+    while src < len(message.args):
+        request.argstreams[dst].write(message.args[src])
+        dst += 1
+        src += 1
+
+    if message.flags != FlagsType.fragment:
+        # get last fragment. mark it as completed
+        assert (len(request.argstreams) ==
+                CallContinueMessage.max_args_num)
+        request.flags = FlagsType.none
+
+    close_argstream(request, dst - 1)
+
+
+def _find_incomplete_stream(reqres):
+    # find the incomplete stream
+    num = 0
+    for i, arg in enumerate(reqres.argstreams):
+        if arg.state != StreamState.completed:
+            num = i
+            break
+    return num
+
+
+def fragment(message, reqres):
+    """Fragment message based on max payload size
+
+    note: if the message doesn't need to fragment,
+    it will return a list which only contains original
+    message itself.
+
+    :param message: raw message
+    :param reqres: request or response object
+    :return: list of messages whose sizes <= max
+        payload size
+    """
+    if message.message_type in [Types.CALL_RES,
+                                Types.CALL_REQ,
+                                Types.CALL_REQ_CONTINUE,
+                                Types.CALL_RES_CONTINUE]:
+        rw = RW[message.message_type]
+        payload_space = (common.MAX_PAYLOAD_SIZE -
+                         rw.length_no_args(message))
+        # split a call/request message into an array
+        # with a call/request message and {0~n} continue
+        # message
+        fragment_msg = message.fragment(payload_space)
+        generate_checksum(message, reqres.checksum[1])
+        reqres.checksum = message.checksum
+
+        yield message
+        while fragment_msg is not None:
+            message = fragment_msg
             rw = RW[message.message_type]
             payload_space = (common.MAX_PAYLOAD_SIZE -
                              rw.length_no_args(message))
-            # split a call/request message into an array
-            # with a call/request message and {0~n} continue
-            # message
             fragment_msg = message.fragment(payload_space)
-            self.generate_checksum(message)
-
+            generate_checksum(message, reqres.checksum[1])
+            reqres.checksum = message.checksum
             yield message
-            while fragment_msg is not None:
-                message = fragment_msg
-                rw = RW[message.message_type]
-                payload_space = (common.MAX_PAYLOAD_SIZE -
-                                 rw.length_no_args(message))
-                fragment_msg = message.fragment(payload_space)
-                self.generate_checksum(message)
-                yield message
-        else:
-            yield message
+    else:
+        yield message
 
-    def generate_checksum(self, message):
-        if message.message_type not in CHECKSUM_MSG_TYPES:
-            return
-        generate_checksum(
-            message,
-            self.out_checksum.get(message.id, 0),
-        )
 
-        self.out_checksum[message.id] = message.checksum[1]
-        if message.flags == FlagsType.none:
-            self.out_checksum.pop(message.id)
+def close_argstream(request, num):
+    # close the stream for completed args since we have received all
+    # the chunks
+    if request.flags == FlagsType.none:
+        num += 1
 
-    def verify_message(self, message):
-        """Verify the checksum of the message."""
-        if verify_checksum(
-                message,
-                self.in_checksum.get(message.id, 0),
-        ):
-            self.in_checksum[message.id] = message.checksum[1]
-
-            if message.flags == FlagsType.none:
-                self.in_checksum.pop(message.id)
-        else:
-            self.in_checksum.pop(message.id, None)
-            raise InvalidChecksumError("Checksum does not match!")
-
-    @staticmethod
-    def close_argstream(request, num):
-        # close the stream for completed args since we have received all
-        # the chunks
-        if request.flags == FlagsType.none:
-            num += 1
-
-        for i in range(num):
-            request.argstreams[i].close()
+    for i in range(num):
+        request.argstreams[i].close()

--- a/tchannel/tornado/request.py
+++ b/tchannel/tornado/request.py
@@ -95,6 +95,7 @@ class Request(object):
             ]
         self.state = StreamState.init
         self.tracing = Trace()
+        self.checksum = (self.checksum[0], 0)
 
     @property
     def arg_scheme(self):

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -97,7 +97,7 @@ class TChannel(object):
         else:
             self._handler = dispatcher
 
-        self.peers = PeerGroup(self)
+        self.peer_group = PeerGroup(self)
 
         self._port = 0
         self._host = None
@@ -123,7 +123,7 @@ class TChannel(object):
 
         if known_peers:
             for peer_hostport in known_peers:
-                self.peers.add(peer_hostport)
+                self.peer_group.add(peer_hostport)
 
         # server created from calling listen()
         self._server = None
@@ -183,7 +183,7 @@ class TChannel(object):
 
         self._state = State.closing
         try:
-            yield self.peers.clear()
+            yield self.peer_group.clear()
         finally:
             self._state = State.closed
 
@@ -221,11 +221,13 @@ class TChannel(object):
         # TODO disallow certain parameters or don't propagate them backwards.
         # For example, blacklist and score threshold aren't really
         # user-configurable right now.
-        return self.peers.request(hostport=hostport,
-                                  service=service,
-                                  arg_scheme=arg_scheme,
-                                  retry=retry,
-                                  **kwargs)
+        return self.peer_group.request(
+            hostport=hostport,
+            service=service,
+            arg_scheme=arg_scheme,
+            retry=retry,
+            **kwargs
+        )
 
     def listen(self, port=None):
         """Start listening for incoming connections.
@@ -396,7 +398,7 @@ class TChannel(object):
 
 
 class TChannelServer(tornado.tcpserver.TCPServer):
-    __slots__ = ('tchannel',)
+    __slots__ = ('tchannel', 'draining')
 
     def __init__(self, tchannel):
         super(TChannelServer, self).__init__()
@@ -419,11 +421,10 @@ class TChannelServer(tornado.tcpserver.TCPServer):
             conn.remote_host_port,
             conn.remote_process_name)
 
-        self.tchannel.peers.get(
+        self.tchannel.peer_group.get(
             "%s:%s" % (conn.remote_host,
                        conn.remote_host_port)
         ).register_incoming(conn)
-
         yield conn.serve(handler=self._handle)
 
     def _handle(self, message, connection):

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -398,7 +398,7 @@ class TChannel(object):
 
 
 class TChannelServer(tornado.tcpserver.TCPServer):
-    __slots__ = ('tchannel', 'draining')
+    __slots__ = ('tchannel',)
 
     def __init__(self, tchannel):
         super(TChannelServer, self).__init__()

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -108,12 +108,12 @@ def test_invalid_message_during_streaming(mock_server):
 
     resp_future = connection.send(callrequest)
     for _ in xrange(10):
-        yield connection._write(callreqcontinue)
+        yield connection.write(callreqcontinue)
 
     # bypass the default checksum calculation
     # set a wrong checksum
     callreqcontinue.checksum = (ChecksumType.crc32c, 1)
-    yield connection._write(callreqcontinue)
+    yield connection.write(callreqcontinue)
 
     with pytest.raises(FatalProtocolError) as e:
         resp = yield resp_future

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -24,7 +24,6 @@ import pytest
 import tornado
 import tornado.gen
 
-from tchannel.errors import BadRequestError
 from tchannel.errors import FatalProtocolError
 from tchannel.messages.call_request import CallRequestMessage
 from tchannel.messages.call_request_continue import CallRequestContinueMessage
@@ -75,7 +74,7 @@ def test_unexpected_error_from_handler(mock_server):
     )
     # set a wrong checksum
     callrequest.checksum = (ChecksumType.crc32c, 1)
-    with pytest.raises(BadRequestError):
+    with pytest.raises(FatalProtocolError):
         yield connection.send(callrequest)
 
 
@@ -109,7 +108,7 @@ def test_invalid_message_during_streaming(mock_server):
 
     resp_future = connection.send(callrequest)
     for _ in xrange(10):
-        yield connection.write(callreqcontinue)
+        yield connection._write(callreqcontinue)
 
     # bypass the default checksum calculation
     # set a wrong checksum

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -69,7 +69,7 @@ class FakeState(PeerState):
 def chain(number_of_peers, endpoint):
     tchannel = TChannel(name='test')
     for i in range(number_of_peers):
-        p = tchannel.peers.get(server(endpoint).hostport)
+        p = tchannel.peer_group.get(server(endpoint).hostport)
         # Gaurantee error servers have score in order to pick first.
         p.state = FakeState()
 
@@ -156,7 +156,7 @@ def test_retry_on_error_success():
     tchannel_success = TChannel(name='test', hostport='localhost:0')
     tchannel_success.register(endpoint, 'raw', handler_success)
     tchannel_success.listen()
-    tchannel.peers.get(tchannel_success.hostport)
+    tchannel.peer_group.get(tchannel_success.hostport)
 
     with (
         patch(

--- a/tests/integration/tornado/test_connection_reuse.py
+++ b/tests/integration/tornado/test_connection_reuse.py
@@ -61,10 +61,10 @@ def test_reuse():
     yield loop1(2)
 
     # Peer representing 2 for 1's point-of-view
-    peer_1_2 = server1.peers.lookup(hostport2)
+    peer_1_2 = server1.peer_group.lookup(hostport2)
 
     # Peer representing 1 from 2's point-of-view
-    peer_2_1 = server2.peers.lookup(hostport1)
+    peer_2_1 = server2.peer_group.lookup(hostport1)
 
     assert len(peer_1_2.outgoing_connections) == 1
     assert len(peer_2_1.incoming_connections) == 1

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -70,7 +70,7 @@ def test_advertise_should_result_in_peer_connections(mock_server):
 
     assert result.headers == {}
     assert result.body == body
-    assert client._dep_tchannel.peers.hosts == routers
+    assert client._dep_tchannel.peer_group.hosts == routers
 
 
 def test_failing_advertise_should_raise(mock_server):

--- a/tests/test_message_factory.py
+++ b/tests/test_message_factory.py
@@ -19,9 +19,14 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-from tchannel.messages import CallRequestMessage, CallResponseMessage
-from tchannel.messages.common import StreamState, FlagsType
-from tchannel.tornado import Request, Response
+
+from tchannel.messages import CallRequestMessage
+from tchannel.messages import CallResponseMessage
+from tchannel.messages import ErrorMessage
+from tchannel.messages.common import FlagsType
+from tchannel.messages.common import StreamState
+from tchannel.tornado import Request
+from tchannel.tornado import Response
 from tchannel.tornado.message_factory import MessageFactory
 from tchannel.tornado.response import StatusCode
 from tchannel.zipkin.trace import Trace
@@ -93,3 +98,12 @@ def test_build_response():
     assert req.flags == message.flags
     assert req.headers == message.headers
     assert req.id == message.id
+
+
+def test_build_inbound_error():
+    message = ErrorMessage(code=0, tracing=Trace(), description="test")
+    error = MessageFactory.build_inbound_error(message)
+
+    assert error.code == message.code
+    assert error.description == message.description
+    assert error.tracing == message.tracing

--- a/tests/test_message_factory.py
+++ b/tests/test_message_factory.py
@@ -27,13 +27,14 @@ from tchannel.messages.common import FlagsType
 from tchannel.messages.common import StreamState
 from tchannel.tornado import Request
 from tchannel.tornado import Response
-from tchannel.tornado.message_factory import MessageFactory
+from tchannel.tornado.message_factory import build_raw_request_message, \
+    build_raw_response_message, build_request, build_response, \
+    build_inbound_error
 from tchannel.tornado.response import StatusCode
 from tchannel.zipkin.trace import Trace
 
 
 def test_build_raw_request_message():
-    message_factory = MessageFactory()
     req = Request(
         ttl=32,
         service="test",
@@ -41,7 +42,7 @@ def test_build_raw_request_message():
         id=1111,
     )
     req.state = StreamState.init
-    message = message_factory.build_raw_request_message(req, None, True)
+    message = build_raw_request_message(req, None, True)
     assert message.ttl / 1000.0 == req.ttl
     assert message.flags == req.flags
     assert message.id == req.id
@@ -50,7 +51,6 @@ def test_build_raw_request_message():
 
 
 def test_build_raw_response_message():
-    message_factory = MessageFactory()
     resp = Response(
         flags=FlagsType.none,
         code=StatusCode.ok,
@@ -59,7 +59,7 @@ def test_build_raw_response_message():
         id=1111,
     )
     resp.state = StreamState.init
-    message = message_factory.build_raw_response_message(resp, None, True)
+    message = build_raw_response_message(resp, None, True)
     assert message.code == resp.code
     assert message.flags == resp.flags
     assert message.id == resp.id
@@ -67,7 +67,6 @@ def test_build_raw_response_message():
 
 
 def test_build_request():
-    message_factory = MessageFactory()
     message = CallRequestMessage(
         flags=FlagsType.none,
         ttl=100,
@@ -76,7 +75,7 @@ def test_build_request():
         id=12,
     )
 
-    req = message_factory.build_request(message)
+    req = build_request(message)
     assert req.ttl == message.ttl / 1000.0
     assert req.flags == message.flags
     assert req.headers == message.headers
@@ -85,7 +84,6 @@ def test_build_request():
 
 
 def test_build_response():
-    message_factory = MessageFactory()
     message = CallResponseMessage(
         flags=FlagsType.none,
         code=StatusCode.ok,
@@ -93,7 +91,7 @@ def test_build_response():
         id=12,
     )
 
-    req = message_factory.build_response(message)
+    req = build_response(message)
     assert req.code == message.code
     assert req.flags == message.flags
     assert req.headers == message.headers
@@ -102,7 +100,7 @@ def test_build_response():
 
 def test_build_inbound_error():
     message = ErrorMessage(code=0, tracing=Trace(), description="test")
-    error = MessageFactory.build_inbound_error(message)
+    error = build_inbound_error(message)
 
     assert error.code == message.code
     assert error.description == message.description

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -27,6 +27,7 @@ import pytest
 from tchannel import messages
 from tchannel.io import BytesIO
 from tchannel.messages import CallRequestMessage
+from tchannel.messages import CallResponseMessage
 from tchannel.messages.common import PROTOCOL_VERSION
 from tchannel.tornado.message_factory import MessageFactory
 from tests.util import big_arg
@@ -266,17 +267,45 @@ def test_equality_check_against_none(init_request_with_headers):
 ],
     ids=lambda arg: str(len(arg))
 )
-def test_message_fragment(arg2, arg3, connection):
+def test_message_fragment_request(arg2, arg3, connection):
     msg = CallRequestMessage(args=["", arg2, arg3])
     origin_msg = CallRequestMessage(args=["", arg2, arg3])
     message_factory = MessageFactory(connection)
     fragments = message_factory.fragment(msg)
-    recv_msg = None
+    request = None
     for fragment in fragments:
-        output = message_factory.build(fragment)
+        output = message_factory.build_inbound_request(fragment, request)
         if output:
-            recv_msg = output
-    header = yield recv_msg.get_header()
-    body = yield recv_msg.get_body()
+            request = output
+    header = yield request.get_header()
+    body = yield request.get_body()
+    assert header == origin_msg.args[1]
+    assert body == origin_msg.args[2]
+
+
+@pytest.mark.gen_test
+@pytest.mark.parametrize('arg2, arg3', [
+    ("", big_arg()),
+    (big_arg(), ""),
+    ("test", big_arg()),
+    (big_arg(),  "test"),
+    (big_arg(), big_arg()),
+    ("", ""),
+    ("test", "test"),
+],
+    ids=lambda arg: str(len(arg))
+)
+def test_message_fragment_response(arg2, arg3, connection):
+    msg = CallResponseMessage(args=["", arg2, arg3])
+    origin_msg = CallResponseMessage(args=["", arg2, arg3])
+    message_factory = MessageFactory(connection)
+    fragments = message_factory.fragment(msg)
+    response = None
+    for fragment in fragments:
+        output = message_factory.build_inbound_response(fragment, response)
+        if output:
+            response = output
+    header = yield response.get_header()
+    body = yield response.get_body()
     assert header == origin_msg.args[1]
     assert body == origin_msg.args[2]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -26,7 +26,7 @@ import pytest
 
 from tchannel import messages
 from tchannel.io import BytesIO
-from tchannel.messages import CallRequestMessage
+from tchannel.messages import CallRequestMessage, Types
 from tchannel.messages import CallResponseMessage
 from tchannel.messages.common import PROTOCOL_VERSION
 from tchannel.tornado.message_factory import MessageFactory
@@ -274,9 +274,10 @@ def test_message_fragment_request(arg2, arg3, connection):
     fragments = message_factory.fragment(msg)
     request = None
     for fragment in fragments:
-        output = message_factory.build_inbound_request(fragment, request)
-        if output:
-            request = output
+        if fragment.message_type == Types.CALL_REQ:
+            request = message_factory.build_inbound_request(fragment)
+        else:
+            message_factory.build_inbound_request_cont(fragment, request)
     header = yield request.get_header()
     body = yield request.get_body()
     assert header == origin_msg.args[1]
@@ -302,9 +303,10 @@ def test_message_fragment_response(arg2, arg3, connection):
     fragments = message_factory.fragment(msg)
     response = None
     for fragment in fragments:
-        output = message_factory.build_inbound_response(fragment, response)
-        if output:
-            response = output
+        if fragment.message_type == Types.CALL_RES:
+            response = message_factory.build_inbound_response(fragment)
+        else:
+            message_factory.build_inbound_response_cont(fragment, response)
     header = yield response.get_header()
     body = yield response.get_body()
     assert header == origin_msg.args[1]

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 
 import pytest
 import tornado.ioloop
+from tornado.iostream import StreamClosedError
 import tornado.testing
 
 from tchannel.messages import Types
@@ -61,3 +62,12 @@ class ConnectionTestCase(tornado.testing.AsyncTestCase):
 
         pong = yield self.client.await()
         assert pong.message_type == Types.PING_RES
+
+    @tornado.testing.gen_test
+    def test_close(self):
+        """Verify the error got thrown when connection is closed"""
+        self.client.ping()
+        yield self.server.await()
+        self.client.connection.close()
+        with pytest.raises(StreamClosedError):
+            yield self.server.await()

--- a/tests/tornado/test_hyperbahn.py
+++ b/tests/tornado/test_hyperbahn.py
@@ -43,7 +43,7 @@ def test_new_client_establishes_peers():
     )
 
     for router in routers:
-        assert channel.peers.lookup(router)
+        assert channel.peer_group.lookup(router)
 
 
 def test_new_client_establishes_peers_from_file():
@@ -67,7 +67,7 @@ def test_new_client_establishes_peers_from_file():
     with open(host_path, 'r') as json_data:
         routers = json.load(json_data)
     for router in routers:
-        assert channel.peers.lookup(router)
+        assert channel.peer_group.lookup(router)
 
 
 @pytest.mark.gen_test

--- a/tests/tornado/test_tchannel.py
+++ b/tests/tornado/test_tchannel.py
@@ -40,8 +40,8 @@ def peer(tchannel):
 @pytest.mark.gen_test
 def test_peer_caching(tchannel, peer):
     "Connections are long-lived and should not be recreated."""
-    tchannel.peers.add(peer)
-    assert tchannel.peers.get("localhost:4040") is peer
+    tchannel.peer_group.add(peer)
+    assert tchannel.peer_group.get("localhost:4040") is peer
 
 
 def test_known_peers():
@@ -49,7 +49,7 @@ def test_known_peers():
     tchannel = TChannel('test', known_peers=peers)
 
     for peer in peers:
-        assert tchannel.peers.lookup(peer)
+        assert tchannel.peer_group.lookup(peer)
 
 
 def test_is_listening_should_return_false_when_listen_not_called(tchannel):


### PR DESCRIPTION
This is patch that refactor the message_factory class to remove state things out of message_factory class. 

More context for this code change:

The origin message_factory is containing some states information like pending request/response in order to build complete request/response. I want to move those states out of message_factory for couple reasons.

1. make message_factory like util class without needing to remember states.
2. those pending request/response information will be used in many other places like draining connection and peer selection.

The other refactors include removing 'isinstance' methods. Explicitly call build_request or build_response. 
Therefore each connection just needs one message_factory class.
