### PR TITLE
Tighten constraints in preparation for 1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changes by Version
 -------------------
 
 - Added Thrift support to ``tcurl.py`` and re-worked the script's arguments.
+- Changed minimum required version of Tornado to 4.2.
 
 
 0.17.3 (unreleased)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -18,16 +18,10 @@ tox
 flake8==2.2.5
 
 # Optional dependency, but must be tested er'ry time
-toro>=0.8,<0.9
-tornado>=4.0,<5.0
 thrift==0.9.2
 
 # Smarter decorators
 wrapt>=1.10,<1.11
-
-# checksum calculation
-pyfarmhash==0.2.0
-crcmod
 
 # Mocks
 mock==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,17 @@ setup(
         '': ['*.thrift'],
     },
     install_requires=[
+        # stdlib backports, no constraints needed
         'contextlib2',
-        'crcmod',
-        'tornado>=4.0,<5.0',
-        'toro>=0.8,<0.9',
+        'futures',
+
+        # external
+        'crcmod>=1,<2',
+        'tornado>=4.2,<5',
+
+        # internal
         'thriftrw>=0.3,<0.4',
         'threadloop>=1,<2',
-        'futures',
     ],
     extras_require={
         'vcr': ['PyYAML', 'mock', 'wrapt'],
@@ -31,3 +35,4 @@ setup(
         ]
     },
 )
+

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,11 @@ setup(
         'contextlib2',
         'futures',
 
-        # external
+        # external deps
         'crcmod>=1,<2',
         'tornado>=4.2,<5',
 
-        # internal
+        # tchannel deps
         'thriftrw>=0.3,<0.4',
         'threadloop>=1,<2',
     ],

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -28,6 +28,8 @@ import sys
 import tornado.gen
 import tornado.iostream
 
+import tornado.queues as queues
+
 from .. import errors
 from .. import frame
 from .. import glossary
@@ -44,13 +46,6 @@ from ..messages.error import ErrorMessage
 from ..messages.types import Types
 from .message_factory import MessageFactory
 from .util import chain
-
-try:
-    import tornado.queues as queues  # included in 4.2
-    QueueEmpty = queues.QueueEmpty
-except ImportError:
-    import toro as queues
-    from Queue import Empty as QueueEmpty
 
 log = logging.getLogger('tchannel')
 
@@ -143,7 +138,7 @@ class TornadoConnection(object):
             while True:
                 message = self._messages.get_nowait()
                 log.warn("Unconsumed message %s", message)
-        except QueueEmpty:
+        except queues.QueueEmpty:
             pass
 
     def await(self):

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -28,6 +28,7 @@ from itertools import chain
 from random import random
 
 from tornado import gen
+from tornado.locks import Condition
 
 from ..schemes import DEFAULT as DEFAULT_SCHEME
 from ..retry import (
@@ -46,12 +47,6 @@ from .stream import InMemStream
 from .stream import read_full
 from .stream import maybe_stream
 from .timeout import timeout
-
-try:
-    # included in Tornado 4.2
-    from tornado.locks import Condition
-except ImportError:  # pragma: no cover
-    from toro import Condition
 
 log = logging.getLogger('tchannel')
 

--- a/tchannel/tornado/stream.py
+++ b/tchannel/tornado/stream.py
@@ -26,15 +26,11 @@ import tornado.gen
 import tornado.ioloop
 from tornado.iostream import PipeIOStream
 from tornado.iostream import StreamClosedError
+from tornado.locks import Condition
 
 from ..errors import UnexpectedError
 from ..messages import common
 from ..messages.common import StreamState
-
-try:
-    from tornado.locks import Condition
-except ImportError:  # pragma: no cover
-    from toro import Condition
 
 
 @tornado.gen.coroutine


### PR DESCRIPTION
This puts us in a state where the only `>1` dependency is `thriftrw`, which should go `1.0` in 4-6 weeks or so. 

* remove deps duplicated in setup.py and requirements-test.txt
* remove toro, up tornado dep to >=4.2
* remove pyfarmhash
* add version constraint to crcmod
* annotate deps in setup.py into 3 different categories, to keep things explicit and clear