### PR TITLE
Fix "app" variable name to be consistent with rest of guide

### DIFF
--- a/GUIDE.rst
+++ b/GUIDE.rst
@@ -252,7 +252,7 @@ instance:
     def run():
 
         tchannel.listen()
-        print('Listening on %s' % app.hostport)
+        print('Listening on %s' % tchannel.hostport)
 
         if os.path.exists('/path/to/hyperbahn_hostlist.json'):
             with open('/path/to/hyperbahn_hostlist.json', 'r') as f:


### PR DESCRIPTION
I believe "app" should be "tchannel".