### PR TITLE
Add matchers argument to use_cassette

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changes by Version
 
 - Added Thrift support to ``tcurl.py`` and re-worked the script's arguments.
 - Changed minimum required version of Tornado to 4.2.
+- Added the ability to customize the attributes ``tchannel.testing.vcr`` uses
+  to match requests for replaying responses.
 - **BREAKING** - headers for JSON handlers are not longer JSON blobs but are
   instead maps of strings to strings. This mirrors behavior for Thrift
   handlers.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ Changes by Version
 
 - Added Thrift support to ``tcurl.py`` and re-worked the script's arguments.
 - Changed minimum required version of Tornado to 4.2.
-- Added the ability to customize the attributes ``tchannel.testing.vcr`` uses
-  to match requests for replaying responses.
+- Specify which request components to match on with VCR, for example, 'header',
+  'body', etc. See ``tchannel.testing.vcr.use_cassette``.
 - **BREAKING** - headers for JSON handlers are not longer JSON blobs but are
   instead maps of strings to strings. This mirrors behavior for Thrift
   handlers.

--- a/tchannel/testing/vcr/__init__.py
+++ b/tchannel/testing/vcr/__init__.py
@@ -37,6 +37,11 @@ The simplest way to use this is with the :py:func:`use_cassette` function.
 Configuration
 -------------
 
+.. py:data:: tchannel.testing.vcr.DEFAULT_MATCHERS
+
+    A tuple containing the default list of matchers used by
+    :py:func:`tchannel.testing.vcr.use_cassette`.
+
 Record Modes
 ~~~~~~~~~~~~
 
@@ -48,6 +53,7 @@ from __future__ import absolute_import
 
 from .config import use_cassette
 from .record_modes import RecordMode
+from .cassette import DEFAULT_MATCHERS
 
 
-__all__ = ['use_cassette', 'RecordMode']
+__all__ = ['use_cassette', 'RecordMode', 'DEFAULT_MATCHERS']

--- a/tchannel/testing/vcr/cassette.py
+++ b/tchannel/testing/vcr/cassette.py
@@ -32,7 +32,7 @@ from .proxy.ttypes import Request
 from .proxy.ttypes import Response
 
 
-__all__ = ['Cassette']
+__all__ = ['Cassette', 'DEFAULT_MATCHERS']
 
 
 # Version of the storage format.
@@ -78,12 +78,9 @@ _MATCHERS = {
 }
 
 
-# By default, two requests match if their service name, hostport, endpoint,
-# headers, body, and arg scheme match.
 DEFAULT_MATCHERS = (
     'serviceName', 'endpoint', 'headers', 'body', 'argScheme',
 )
-# TODO: protocol headers?
 
 
 class Cassette(object):
@@ -100,9 +97,7 @@ class Cassette(object):
         :param matchers:
             If specified, this is a collection of matcher names. These
             specify which attributes on two requests should match for them to
-            be considered equal. This may also be a function that transforms
-            a list of matcher names, in which case it will be applied to the
-            default list of matchers and the result will be used.
+            be considered equal.
         """
         # TODO move documentation around
         record_mode = record_mode or RecordMode.ONCE
@@ -117,8 +112,6 @@ class Cassette(object):
 
         if matchers is None:
             matchers = DEFAULT_MATCHERS
-        elif callable(matchers):
-            matchers = matchers(list(DEFAULT_MATCHERS))
 
         self._matchers = []
         for m in matchers:

--- a/tchannel/testing/vcr/cassette.py
+++ b/tchannel/testing/vcr/cassette.py
@@ -100,7 +100,9 @@ class Cassette(object):
         :param matchers:
             If specified, this is a collection of matcher names. These
             specify which attributes on two requests should match for them to
-            be considered equal.
+            be considered equal. This may also be a function that transforms
+            a list of matcher names, in which case it will be applied to the
+            default list of matchers and the result will be used.
         """
         # TODO move documentation around
         record_mode = record_mode or RecordMode.ONCE
@@ -113,7 +115,11 @@ class Cassette(object):
         # this was a new cassette and the YAML file did not exist.
         self.existed = False
 
-        matchers = matchers or DEFAULT_MATCHERS
+        if matchers is None:
+            matchers = DEFAULT_MATCHERS
+        elif callable(matchers):
+            matchers = matchers(list(DEFAULT_MATCHERS))
+
         self._matchers = []
         for m in matchers:
             try:

--- a/tchannel/testing/vcr/config.py
+++ b/tchannel/testing/vcr/config.py
@@ -147,34 +147,27 @@ def use_cassette(path, record_mode=None, inject=False, matchers=None):
         object will be injected into the function call as the first argument.
         Defaults to False.
     :param matchers:
-        Used to configure the request attributes which VCR matches on. This is
-        a list of request attributes or a function that accepts a list of
-        request attributes and returns a new list of attributes. This function
-        will be called with the default list of attributes used by VCR and the
-        result will be the list of matchers used. A recorded response will be
-        replayed if all specified attributes of the corresponding request
-        match the request that is being made. Valid attributes are:
-        ``serviceName``, ``hostPort``, ``endpoint``, ``headers``, ``body``,
-        ``argScheme``, and ``transportHeaders``.
+        Used to configure the request attributes which VCR matches on. A
+        recorded response will be replayed if all specified attributes of the
+        corresponding request match the request that is being made. Valid
+        attributes are: ``serviceName``, ``hostPort``, ``endpoint``,
+        ``headers``, ``body``, ``argScheme``, and ``transportHeaders``.
 
         For example,
 
         .. code-block:: python
 
-            @vcr.use_cassette('tests/data/foo.yaml', matchers=['body']):
+            MY_MATCHERS = list(vcr.DEFAULT_MATCHERS)
+            MY_MATCHERS.remove('headers')
+
+            @vcr.use_cassette('tests/data/foo.yaml', matchers=MY_MATCHERS):
             def test_foo():
-                # ...
-
-            def no_headers(matchers):
-                matchers.remove('headers')
-                return matchers
-
-            @vcr.use_cassette('tests/data/bar.yaml', matchers=no_headers):
-            def test_bar():
                 # ...
 
         By default, the following attributes are matched: ``serviceName``,
         ``endpoint``, ``headers``, ``body``, and ``argScheme``.
+        :py:data:`tchannel.testing.vcr.DEFAULT_MATCHERS` is a tuple of all
+        these matchers.
     """
 
     return _CassetteContext(

--- a/tchannel/testing/vcr/config.py
+++ b/tchannel/testing/vcr/config.py
@@ -149,12 +149,13 @@ def use_cassette(path, record_mode=None, inject=False, matchers=None):
     :param matchers:
         Used to configure the request attributes which VCR matches on. This is
         a list of request attributes or a function that accepts a list of
-        request attributes and returns a new list of attributes (this may be
-        used to transform the default list of matchers used by VCR).  A
-        recorded response is replayed if all specified attributes of the
-        corresponding request match the request that is being made. Valid
-        attirbutes are: ``serviceName``, ``hostPort``, ``endpoint``,
-        ``headers``, ``body``, ``argScheme``, and ``transportHeaders``.
+        request attributes and returns a new list of attributes. This function
+        will be called with the default list of attributes used by VCR and the
+        result will be the list of matchers used. A recorded response will be
+        replayed if all specified attributes of the corresponding request
+        match the request that is being made. Valid attributes are:
+        ``serviceName``, ``hostPort``, ``endpoint``, ``headers``, ``body``,
+        ``argScheme``, and ``transportHeaders``.
 
         For example,
 
@@ -172,7 +173,7 @@ def use_cassette(path, record_mode=None, inject=False, matchers=None):
             def test_bar():
                 # ...
 
-        By default, VCR matches on the attributes: ``serviceName``,
+        By default, the following attributes are matched: ``serviceName``,
         ``endpoint``, ``headers``, ``body``, and ``argScheme``.
     """
 

--- a/tests/testing/vcr/test_cassette.py
+++ b/tests/testing/vcr/test_cassette.py
@@ -186,3 +186,23 @@ def test_record_mode_all(path):
 
     with Cassette(str(path)) as cass:
         assert res2 == cass.replay(req)
+
+
+def test_matcher_transform(path):
+    def remove_headers(matchers):
+        # don't match on headers
+        matchers.remove('headers')
+        return matchers
+
+    request = requests.example()
+    response = responses.example()
+
+    with Cassette(str(path), matchers=remove_headers) as cass:
+        cass.record(request, response)
+
+    request.headers = 'foo'
+
+    with Cassette(str(path), matchers=remove_headers) as cass:
+        assert cass.can_replay(request)
+        assert cass.replay(request) == response
+        assert cass.play_count == 1

--- a/tests/testing/vcr/test_cassette.py
+++ b/tests/testing/vcr/test_cassette.py
@@ -186,23 +186,3 @@ def test_record_mode_all(path):
 
     with Cassette(str(path)) as cass:
         assert res2 == cass.replay(req)
-
-
-def test_matcher_transform(path):
-    def remove_headers(matchers):
-        # don't match on headers
-        matchers.remove('headers')
-        return matchers
-
-    request = requests.example()
-    response = responses.example()
-
-    with Cassette(str(path), matchers=remove_headers) as cass:
-        cass.record(request, response)
-
-    request.headers = 'foo'
-
-    with Cassette(str(path), matchers=remove_headers) as cass:
-        assert cass.can_replay(request)
-        assert cass.replay(request) == response
-        assert cass.play_count == 1


### PR DESCRIPTION
This allows customizing the list of request attributes used matched by VCR to
determine if two requests should be considered equal. 

CC @blampe @breerly @junchaowu 
