### PR TITLE
TChannel.get_instance() returns makes TChannel act like a singleton

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes by Version
 0.18.0 (unreleased)
 -------------------
 
+- Added singleton facility for maintaining a single TChannel instance per thread.
+  See ``tchannel.singleton.TChannel``, ``tchannel.sync.singleton.TChannel``, or check
+  the guide for an example how of how to use. Note this feature is optional.
 - Added Thrift support to ``tcurl.py`` and re-worked the script's arguments.
 - Changed minimum required version of Tornado to 4.2.
 - **BREAKING** - headers for JSON handlers are not longer JSON blobs but are

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,6 +9,9 @@ TChannel
     :special-members: __init__
     :members:
 
+.. autoclass:: tchannel.singleton.TChannel
+    :members:
+
 .. autoclass:: tchannel.Request
     :members:
 
@@ -67,6 +70,10 @@ Synchronous Client
 ------------------
 
 .. autoclass:: tchannel.sync.TChannel
+    :inherited-members:
+    :members:
+
+.. autoclass:: tchannel.sync.singleton.TChannel
     :inherited-members:
     :members:
 

--- a/tchannel/errors.py
+++ b/tchannel/errors.py
@@ -191,3 +191,8 @@ class OneWayNotSupportedError(BadRequestError):
 class ValueExpectedError(BadRequestError):
     """Raised when a non-void Thrift response contains no value."""
     pass
+
+
+class SingletonNotPreparedError(TChannelError):
+    """Raised when calling get_instance before calling prepare."""
+    pass

--- a/tchannel/singleton.py
+++ b/tchannel/singleton.py
@@ -1,0 +1,39 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+from threading import local
+
+from tchannel import TChannel as AsyncTChannel
+
+
+class TChannel(object):
+
+    prepared = False
+    args = None
+    kwargs = None
+
+    tchannel_cls = AsyncTChannel
+
+    local = local()
+    local.tchannel = None
+
+    @classmethod
+    def prepare(cls, *args, **kwargs):
+        cls.args = args
+        cls.kwargs = kwargs
+        cls.prepared = True
+
+    @classmethod
+    def get_instance(cls):
+
+        if not cls.prepared:
+            # TODO use better exception
+            raise Exception("prepare must be called before get_instance")
+
+        if hasattr(cls.local, 'tchannel') and cls.local.tchannel is not None:
+            return cls.local.tchannel
+
+        cls.local.tchannel = cls.tchannel_cls(*cls.args, **cls.kwargs)
+
+        return cls.local.tchannel

--- a/tchannel/singleton.py
+++ b/tchannel/singleton.py
@@ -4,10 +4,12 @@ from __future__ import (
 
 from threading import local
 
-from tchannel import TChannel as AsyncTChannel
+from . import TChannel as AsyncTChannel
+from .errors import TChannelError
 
 
 class TChannel(object):
+    """Maintain a single TChannel instance per-thread."""
 
     prepared = False
     args = None
@@ -20,16 +22,24 @@ class TChannel(object):
 
     @classmethod
     def prepare(cls, *args, **kwargs):
+        """Set arguments to be used when instantiating a TChannel instance.
+
+        TODO somehow inherit TChannel.init docs
+        """
         cls.args = args
         cls.kwargs = kwargs
         cls.prepared = True
 
     @classmethod
     def get_instance(cls):
+        """Get a configured, thread-safe, singleton TChannel instance.
 
+        :returns tchannel.TChannel:
+        """
         if not cls.prepared:
-            # TODO use better exception
-            raise Exception("prepare must be called before get_instance")
+            raise SingletonNotPreparedError(
+                "prepare must be called before get_instance"
+            )
 
         if hasattr(cls.local, 'tchannel') and cls.local.tchannel is not None:
             return cls.local.tchannel
@@ -37,3 +47,8 @@ class TChannel(object):
         cls.local.tchannel = cls.tchannel_cls(*cls.args, **cls.kwargs)
 
         return cls.local.tchannel
+
+
+class SingletonNotPreparedError(TChannelError):
+    """Raised when calling get_instance before calling prepare."""
+    pass

--- a/tchannel/singleton.py
+++ b/tchannel/singleton.py
@@ -24,7 +24,8 @@ class TChannel(object):
     def prepare(cls, *args, **kwargs):
         """Set arguments to be used when instantiating a TChannel instance.
 
-        TODO somehow inherit TChannel.init docs
+        Arguments are the same as :py:meth:`tchannel.TChannel.__init__`
+
         """
         cls.args = args
         cls.kwargs = kwargs

--- a/tchannel/singleton.py
+++ b/tchannel/singleton.py
@@ -24,8 +24,7 @@ class TChannel(object):
     def prepare(cls, *args, **kwargs):
         """Set arguments to be used when instantiating a TChannel instance.
 
-        Arguments are the same as :py:meth:`tchannel.TChannel.__init__`
-
+        Arguments are the same as :py:meth:`tchannel.TChannel.__init__`.
         """
         cls.args = args
         cls.kwargs = kwargs

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -25,4 +25,4 @@ class TChannel(TChannelSingleton):
 
         :returns: tchannel.sync.TChannel
         """
-        return supet(TChannel, cls).get_instance()
+        return super(TChannel, cls).get_instance()

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -1,0 +1,12 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+from tchannel.singleton import TChannel as TChannelSingleton
+
+from .client import TChannel as SyncTChannel
+
+
+class TChannel(TChannelSingleton):
+
+    tchannel_cls = SyncTChannel

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -2,11 +2,16 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+from threading import local
+
 from tchannel.singleton import TChannel as TChannelSingleton
 
 from .client import TChannel as SyncTChannel
 
 
 class TChannel(TChannelSingleton):
+
+    local = local()
+    local.tchannel = None
 
     tchannel_cls = SyncTChannel

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -18,3 +18,11 @@ class TChannel(TChannelSingleton):
     prepared = False
     args = None
     kwargs = None
+
+    @classmethod
+    def get_instance(cls):
+        """Get a configured, thread-safe, singleton TChannel instance.
+
+        :returns: tchannel.sync.TChannel
+        """
+        return supet(TChannel, cls).get_instance()

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -10,7 +10,11 @@ from .client import TChannel as SyncTChannel
 
 class TChannel(TChannelSingleton):
 
+    tchannel_cls = SyncTChannel
+
     local = local()
     local.tchannel = None
 
-    tchannel_cls = SyncTChannel
+    prepared = False
+    args = None
+    kwargs = None

--- a/tchannel/sync/singleton.py
+++ b/tchannel/sync/singleton.py
@@ -5,7 +5,6 @@ from __future__ import (
 from threading import local
 
 from tchannel.singleton import TChannel as TChannelSingleton
-
 from .client import TChannel as SyncTChannel
 
 

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -25,7 +25,7 @@ from __future__ import (
 import json
 import logging
 
-from threading import Lock, local
+from threading import Lock
 from tornado import gen
 
 from . import schemes
@@ -43,10 +43,6 @@ from .tornado.dispatch import RequestDispatcher as DeprecatedDispatcher
 log = logging.getLogger('tchannel')
 
 __all__ = ['TChannel']
-
-# storage for thread-local tchannel singleton
-_local = local()
-_local.tchannel = None
 
 
 class TChannel(object):
@@ -121,22 +117,6 @@ class TChannel(object):
         self._listen_lock = Lock()
         # register default health endpoint
         self.thrift.register(Meta)(health)
-
-    @classmethod
-    def get_instance(cls, *args, **kwargs):
-        """Instantiate a TChannel singleton, when needed.
-
-        :returns TChannel: a per-process singleton instance
-        """
-
-        global _local
-
-        if hasattr(_local, 'tchannel') and _local.tchannel is not None:
-            return _local.tchannel
-
-        _local.tchannel = TChannel(*args, **kwargs)
-
-        return _local.tchannel
 
     def is_listening(self):
         return self._dep_tchannel.is_listening()

--- a/tests/sync/test_singleton.py
+++ b/tests/sync/test_singleton.py
@@ -1,0 +1,25 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+import pytest
+
+from tchannel.sync.singleton import TChannel
+from tchannel.sync import TChannel as SyncTChannel
+from tchannel.singleton import TChannel as AsyncSingleton
+from tchannel.errors import SingletonNotPreparedError
+
+
+def test_stored_seperately_from_async_singleton():
+
+    AsyncSingleton.prepare('async-app')
+
+    with pytest.raises(SingletonNotPreparedError):
+        TChannel.get_instance()
+
+    TChannel.prepare('sync-app')
+
+    instance = TChannel.get_instance()
+
+    assert isinstance(instance,  SyncTChannel)
+    assert AsyncSingleton.get_instance() is not instance

--- a/tests/sync/test_singleton.py
+++ b/tests/sync/test_singleton.py
@@ -12,6 +12,9 @@ from tchannel.errors import SingletonNotPreparedError
 
 def test_stored_seperately_from_async_singleton():
 
+    TChannel.reset()
+    AsyncSingleton.reset()
+
     AsyncSingleton.prepare('async-app')
 
     with pytest.raises(SingletonNotPreparedError):

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -10,23 +10,27 @@ from tchannel.errors import SingletonNotPreparedError
 
 
 def test_get_instance_is_singleton():
-    TChannel.prepare('my-app')
-    assert TChannel.get_instance() is TChannel.get_instance()
+
     TChannel.reset()
+    TChannel.prepare('my-app')
+
+    assert TChannel.get_instance() is TChannel.get_instance()
 
 
 def test_must_call_prepare_before_get_instance():
+
+    TChannel.reset()
+
     with pytest.raises(SingletonNotPreparedError):
         TChannel.get_instance()
 
 
 def test_get_instance_returns_configured_tchannel():
 
+    TChannel.reset()
     TChannel.prepare('my-app')
 
     tchannel = TChannel.get_instance()
 
     assert isinstance(tchannel, AsyncTChannel)
     assert tchannel.name == 'my-app'
-
-    TChannel.reset()

--- a/tests/test_singleton.py
+++ b/tests/test_singleton.py
@@ -1,0 +1,32 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+import pytest
+
+from tchannel import TChannel as AsyncTChannel
+from tchannel.singleton import TChannel
+from tchannel.errors import SingletonNotPreparedError
+
+
+def test_get_instance_is_singleton():
+    TChannel.prepare('my-app')
+    assert TChannel.get_instance() is TChannel.get_instance()
+    TChannel.reset()
+
+
+def test_must_call_prepare_before_get_instance():
+    with pytest.raises(SingletonNotPreparedError):
+        TChannel.get_instance()
+
+
+def test_get_instance_returns_configured_tchannel():
+
+    TChannel.prepare('my-app')
+
+    tchannel = TChannel.get_instance()
+
+    assert isinstance(tchannel, AsyncTChannel)
+    assert tchannel.name == 'my-app'
+
+    TChannel.reset()


### PR DESCRIPTION
Applications that want to avoid global state can instantiate a `TChannel` object themselves, passing the instance around to where it's needed. 

In some cases, an applications code has no way to avoid global state, and they end up writing their own singleton facility - in this case, as simple & thread-safe `TChannel.get_instance()` function can save them a lot of time and hassle.

- [x] implementation
- [x] tests
- [x] docs