### PR TITLE
turn on default checksum to crc32c

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.17.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Set default checksum to ``CRC32C``.
 
 
 0.17.4 (2015-10-12)
@@ -12,7 +12,6 @@ Changes by Version
 
 - Updated ``vcr`` to use ``thriftrw``-generated code. This should resolve some
   unicode errors during testing with ``vcr``.
-- Set default checksum to ``CRC32C``.
 
 
 0.17.3 (2015-10-09)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changes by Version
 
 - Updated ``vcr`` to use ``thriftrw``-generated code. This should resolve some
   unicode errors during testing with ``vcr``.
+- Set default checksum to ``CRC32C``.
 
 
 0.17.3 (2015-10-09)

--- a/tchannel/tornado/request.py
+++ b/tchannel/tornado/request.py
@@ -29,6 +29,7 @@ from tchannel import retry
 
 from ..glossary import DEFAULT_TIMEOUT
 from ..messages import ErrorCode
+from ..messages.common import ChecksumType
 from ..messages.common import FlagsType
 from ..messages.common import StreamState
 from ..serializer.raw import RawSerializer
@@ -68,7 +69,7 @@ class Request(object):
         self.argstreams = argstreams or [InMemStream(),
                                          InMemStream(),
                                          InMemStream()]
-        self.checksum = checksum
+        self.checksum = checksum or (ChecksumType.crc32c, 0)
         self.id = id
         self.headers = headers or {}
         self.state = StreamState.init

--- a/tchannel/tornado/response.py
+++ b/tchannel/tornado/response.py
@@ -25,6 +25,7 @@ import tornado.gen
 
 from ..enum import enum
 from ..errors import TChannelError
+from ..messages.common import ChecksumType
 from ..messages.common import FlagsType
 from ..messages.common import StreamState
 from ..serializer.raw import RawSerializer
@@ -62,7 +63,7 @@ class Response(object):
         self.flags = flags or FlagsType.none
         self.code = code or StatusCode.ok
         self.tracing = tracing
-        self.checksum = checksum
+        self.checksum = checksum or (ChecksumType.crc32c, 0)
         # argstreams is a list of InMemStream/PipeStream objects
         self.argstreams = argstreams or [InMemStream(),
                                          InMemStream(),


### PR DESCRIPTION
Somehow the existing tchannel doesn't turn on the checksum to crc32c. 
manually test the via node tcurl.