### PR TITLE
Deprecation warnings for functionality that will soon be removed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Changes by Version
 
 - Deprecated warnings will now sound for ``tchannel.thrift.client_for``,
   ``tchannel.thrift_request_builder``, and ``tchannel.tornado.TChannel`` - these
-  will be removed soon - be sure to move to ``tchannel.thrift.load`` in
+  APIs will be removed soon - be sure to move to ``tchannel.thrift.load`` in
   conjunction with ``tchannel.TChannel``.
 - Added singleton facility for maintaining a single TChannel instance per thread.
   See ``tchannel.singleton.TChannel``, ``tchannel.sync.singleton.TChannel``, or check

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes by Version
 0.18.0 (unreleased)
 -------------------
 
+- Deprecated warnings will now sound for ``tchannel.thrift.client_for``,
+  ``tchannel.thrift_request_builder``, and ``tchannel.tornado.TChannel`` - these
+  will be removed soon - be sure to move to ``tchannel.thrift.load`` in
+  conjunction with ``tchannel.TChannel``.
 - Added singleton facility for maintaining a single TChannel instance per thread.
   See ``tchannel.singleton.TChannel``, ``tchannel.sync.singleton.TChannel``, or check
   the guide for an example how of how to use. Note this feature is optional.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,8 +31,6 @@ Thrift
 .. autoclass:: tchannel.schemes.ThriftArgScheme
     :members: __call__, register
 
-.. autofunction:: tchannel.thrift_request_builder
-
 .. autofunction:: tchannel.thrift.load
 
 JSON

--- a/tchannel/deprecate.py
+++ b/tchannel/deprecate.py
@@ -1,0 +1,24 @@
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+
+import functools
+import warnings
+
+
+def deprecate(message):
+    """Loudly prints warning."""
+    warnings.simplefilter('default')
+    warnings.warn(message, category=DeprecationWarning)
+    warnings.resetwarnings()
+
+
+def deprecated(message):
+    """Warn every time a fn is called."""
+    def decorator(fn):
+        @functools.wraps(fn)
+        def new_fn(*args, **kwargs):
+            deprecate(message)
+            return fn(*args, **kwargs)
+        return new_fn
+    return decorator

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -106,6 +106,7 @@ class TChannel(object):
             known_peers=known_peers,
             trace=trace,
             dispatcher=DeprecatedDispatcher(_handler_returns_response=True),
+            _from_new_api=True,
         )
 
         self.name = name

--- a/tchannel/thrift/client.py
+++ b/tchannel/thrift/client.py
@@ -41,8 +41,8 @@ _ClientBase = namedtuple(
 
 
 @deprecated(
-    "client_for is deprecated and will be removed in 0.19.0, " +
-    "please switch usage to tchannel.thrift.load in conjunction " +
+    "client_for is deprecated and will be removed in 0.19.0, "
+    "please switch usage to tchannel.thrift.load in conjunction "
     "with tchannel.TChannel or tchannel.sync.TChannel."
 )
 def client_for(service, service_module, thrift_service_name=None):

--- a/tchannel/thrift/client.py
+++ b/tchannel/thrift/client.py
@@ -32,7 +32,6 @@ from tchannel.errors import OneWayNotSupportedError
 from ..serializer.thrift import ThriftSerializer
 from .reflection import get_service_methods
 
-
 # Generated clients will use this base class.
 _ClientBase = namedtuple(
     '_ClientBase',

--- a/tchannel/thrift/client.py
+++ b/tchannel/thrift/client.py
@@ -26,10 +26,12 @@ from collections import namedtuple
 from tornado import gen
 
 from tchannel import schemes
+from tchannel.deprecate import deprecated
 from tchannel.errors import OneWayNotSupportedError
 
 from ..serializer.thrift import ThriftSerializer
 from .reflection import get_service_methods
+
 
 # Generated clients will use this base class.
 _ClientBase = namedtuple(
@@ -38,6 +40,11 @@ _ClientBase = namedtuple(
 )
 
 
+@deprecated(
+    "client_for is deprecated and will be removed in 0.19.0, " +
+    "please switch usage to tchannel.thrift.load in conjunction " +
+    "with tchannel.TChannel or tchannel.sync.TChannel."
+)
 def client_for(service, service_module, thrift_service_name=None):
     """Build a client class for the given Thrift service.
 

--- a/tchannel/thrift/module.py
+++ b/tchannel/thrift/module.py
@@ -25,6 +25,7 @@ from __future__ import (
 import inspect
 import types
 
+from tchannel.deprecate import deprecated
 from tchannel.errors import ValueExpectedError
 from tchannel.errors import OneWayNotSupportedError
 from tchannel.serializer.thrift import ThriftSerializer
@@ -32,6 +33,10 @@ from tchannel.serializer.thrift import ThriftSerializer
 from .reflection import get_service_methods, get_module_name
 
 
+@deprecated(
+    "thrift_request_builder is deprecated and will be removed in 0.19.0. " +
+    "please switch usage to tchannel.load."
+)
 def thrift_request_builder(service, thrift_module, hostport=None,
                            thrift_class_name=None):
     """Provide TChannel compatibility with Thrift-generated modules.

--- a/tchannel/thrift/module.py
+++ b/tchannel/thrift/module.py
@@ -34,8 +34,8 @@ from .reflection import get_service_methods, get_module_name
 
 
 @deprecated(
-    "thrift_request_builder is deprecated and will be removed in 0.19.0. " +
-    "please switch usage to tchannel.load."
+    "thrift_request_builder is deprecated and will be removed in 0.19.0. "
+    "please switch usage to tchannel.thrift.load."
 )
 def thrift_request_builder(service, thrift_module, hostport=None,
                            thrift_class_name=None):

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -33,6 +33,7 @@ import tornado.tcpserver
 from tornado.netutil import bind_sockets
 
 from . import hyperbahn
+from ..deprecate import deprecate
 from ..enum import enum
 from ..errors import AlreadyListeningError
 from ..event import EventEmitter
@@ -65,7 +66,8 @@ class TChannel(object):
     FALLBACK = RequestDispatcher.FALLBACK
 
     def __init__(self, name, hostport=None, process_name=None,
-                 known_peers=None, trace=False, dispatcher=None):
+                 known_peers=None, trace=False, dispatcher=None,
+                 _from_new_api=False):
         """Build or re-use a TChannel.
 
         :param name:
@@ -90,6 +92,7 @@ class TChannel(object):
             Flag to turn on/off zipkin trace. It can be a bool variable or
             a function that return true or false.
         """
+
         self._state = State.ready
 
         if not dispatcher:
@@ -127,6 +130,14 @@ class TChannel(object):
 
         # server created from calling listen()
         self._server = None
+
+        # warn if customers are still using this old and soon to be delted api
+        if _from_new_api is False:
+            deprecate(
+                "tchannel.tornado.TChannel is deprecated and will be removed" +
+                " in a a future version - please switch usage to " +
+                "tchannel.TChannel object. Thank you."
+            )
 
     @property
     def trace(self):

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -131,7 +131,7 @@ class TChannel(object):
         # server created from calling listen()
         self._server = None
 
-        # warn if customers are still using this old and soon to be delted api
+        # warn if customers are still using this old and soon to be deleted api
         if _from_new_api is False:
             deprecate(
                 "tchannel.tornado.TChannel is deprecated and will be removed" +


### PR DESCRIPTION
To see how the warnings will look, run `make test test_args="-s"` and search for "DeprecatedWarning".

@blampe @junchaowu @abhinav 

It's not pretty but gets the job done.
