### PR TITLE
remove reset condition from the ``clear`` method in peer group

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -325,7 +325,8 @@ class TornadoConnection(object):
         return self.connection.write(body)
 
     def close(self):
-        self.connection.close()
+        if not self.connection.closed():
+            self.connection.close()
 
     @tornado.gen.coroutine
     def initiate_handshake(self, headers):

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -26,9 +26,7 @@ import logging
 from collections import deque
 from itertools import chain
 from random import random
-
 from tornado import gen
-from tornado.locks import Condition
 
 from ..schemes import DEFAULT as DEFAULT_SCHEME
 from ..retry import (
@@ -87,7 +85,6 @@ class PeerGroup(object):
     def __str__(self):
         return "<PeerGroup peers=%s>" % str(self._peers)
 
-    @gen.coroutine
     def clear(self):
         """Reset this PeerGroup.
 
@@ -98,23 +95,12 @@ class PeerGroup(object):
             A Future that resolves with a value of None when the operation
             has finished
         """
-        if self._resetting:
-            # If someone else is already resetting the PeerGroup, just block
-            # on them to be finished.
-            yield self._reset_condition.wait()
-            raise gen.Return(None)
-
-        self._resetting = True
-        if self._reset_condition is None:
-            self._reset_condition = Condition()
-
         try:
             for peer in self._peers.values():
                 peer.close()
         finally:
             self._peers = {}
             self._resetting = False
-            self._reset_condition.notify_all()
 
     def get(self, hostport):
         """Get a Peer for the given destination.

--- a/tests/tornado/test_peer.py
+++ b/tests/tornado/test_peer.py
@@ -94,28 +94,6 @@ def test_maybe_stream(s, expected):
 
 
 @pytest.mark.gen_test
-def test_peer_group_clear_multiple():
-    # Multiple concurrent reset attempts should not conflict with each other.
-
-    peer_group = tpeer.PeerGroup(mock.MagicMock())
-    for i in xrange(10):
-        peer_group.get('localhost:404%d' % i)
-
-    # A peer that will intentionally take a while to close.
-    dirty_peer = mock.MagicMock()
-    dirty_peer.close.side_effect = lambda: gen.sleep(0.1)
-    peer_group.add(dirty_peer)
-
-    yield [peer_group.clear() for i in xrange(10)]
-
-    # Dirty peer must have been closed only once.
-    dirty_peer.close.assert_called_once_with()
-
-    for i in xrange(10):
-        assert not peer_group.lookup('localhost:404%d' % i)
-
-
-@pytest.mark.gen_test
 def test_peer_connection_failure():
     # Test connecting a peer when the first connection attempt fails.
 


### PR DESCRIPTION
remove reset condition from the ``clear`` method in peer group
at the same time to make the method non-coroutine.
Add connection.closed() check before call close.