### PR TITLE
Timeout in seconds, not milliseconds.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes by Version
 ==================
 
+0.17.9 (unreleased)
+-------------------
+
+- Change default timeout to 30 seconds, from 16 minutes.
+
 0.17.8 (2015-10-14)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.17.9 (unreleased)
 -------------------
 
-- Change default timeout to 30 seconds, from 16 minutes.
+- Fix default timeout incorrectly set to 16 minutes, now 30 seconds.
 
 0.17.8 (2015-10-14)
 -------------------

--- a/tchannel/glossary.py
+++ b/tchannel/glossary.py
@@ -24,4 +24,4 @@
 MAX_MESSAGE_ID = 0xfffffffe
 
 # CallRequestMessage uses it as the default TTL value for the message.
-DEFAULT_TIMEOUT = 1000  # ms
+DEFAULT_TIMEOUT = 30  # seconds

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -76,8 +76,8 @@ class JsonArgScheme(object):
         :param string headers:
             A raw headers block to provide to the endpoint.
         :param int timeout:
-            How long to wait (in ms) before raising a ``TimeoutError`` - this
-            defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
+            How long to wait (in seconds) before raising a ``TimeoutError`` -
+            this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
         :param string retry_on:
             What events to retry on - valid values can be found in
             ``tchannel.retry``.

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -75,7 +75,7 @@ class JsonArgScheme(object):
             A raw body to provide to the endpoint.
         :param string headers:
             A raw headers block to provide to the endpoint.
-        :param int timeout:
+        :param float timeout:
             How long to wait (in seconds) before raising a ``TimeoutError`` -
             this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
         :param string retry_on:

--- a/tchannel/schemes/raw.py
+++ b/tchannel/schemes/raw.py
@@ -74,8 +74,8 @@ class RawArgScheme(object):
         :param string headers:
             A raw headers block to provide to the endpoint.
         :param int timeout:
-            How long to wait (in ms) before raising a ``TimeoutError`` - this
-            defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
+            How long to wait (in seconds) before raising a ``TimeoutError`` -
+            this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
         :param string retry_on:
             What events to retry on - valid values can be found in
             ``tchannel.retry``.

--- a/tchannel/schemes/raw.py
+++ b/tchannel/schemes/raw.py
@@ -73,7 +73,7 @@ class RawArgScheme(object):
             A raw body to provide to the endpoint.
         :param string headers:
             A raw headers block to provide to the endpoint.
-        :param int timeout:
+        :param float timeout:
             How long to wait (in seconds) before raising a ``TimeoutError`` -
             this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
         :param string retry_on:

--- a/tchannel/sync/client.py
+++ b/tchannel/sync/client.py
@@ -51,7 +51,7 @@ class TChannel(AsyncTChannel):
         # thrift_service is the result of a call to ``thrift_request_builder``
         future = tchannel.thrift(
             thrift_service.getItem('foo'),
-            timeout=1000,  #  1 second
+            timeout=2,  #  2 seconds
         )
 
         result = future.result()

--- a/tchannel/sync/client.py
+++ b/tchannel/sync/client.py
@@ -51,7 +51,7 @@ class TChannel(AsyncTChannel):
         # thrift_service is the result of a call to ``thrift_request_builder``
         future = tchannel.thrift(
             thrift_service.getItem('foo'),
-            timeout=2,  #  2 seconds
+            timeout=0.5,  #  0.5 seconds
         )
 
         result = future.result()

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -104,6 +104,7 @@ def test_timeout_should_raise_timeout_error():
     server = TChannel(name='server')
 
     @server.register(scheme=schemes.RAW)
+    @gen.coroutine
     def endpoint(request):
         yield gen.sleep(0.05)
         raise gen.Return('hello')
@@ -125,12 +126,11 @@ def test_timeout_should_raise_timeout_error():
         )
 
     # timeout is greater than sleep, should get resp
-    yield tchannel.call(
-        scheme=schemes.RAW,
+    yield tchannel.raw(
         service='server',
-        arg1='endpoint',
+        endpoint='endpoint',
         hostport=server.hostport,
-        timeout=1,
+        timeout=0.1,
     )
 
 

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -34,7 +34,7 @@ import pytest
 from tornado import gen
 
 from tchannel import TChannel, Request, Response, schemes, errors
-from tchannel.errors import AlreadyListeningError
+from tchannel.errors import AlreadyListeningError, TimeoutError
 from tchannel.event import EventHook
 from tchannel.response import TransportHeaders
 
@@ -93,6 +93,45 @@ def test_call_should_get_response():
     assert isinstance(resp.transport, TransportHeaders)
     assert resp.transport.scheme == schemes.RAW
     assert resp.transport.failure_domain is None
+
+
+@pytest.mark.gen_test
+@pytest.mark.call
+def test_timeout_should_raise_timeout_error():
+
+    # Given this test server:
+
+    server = TChannel(name='server')
+
+    @server.register(scheme=schemes.RAW)
+    def endpoint(request):
+        yield gen.sleep(0.05)
+        raise gen.Return('hello')
+
+    server.listen()
+
+    # Make a call:
+
+    tchannel = TChannel(name='client')
+
+    # timeout is less than sleep, should get error
+    with pytest.raises(TimeoutError):
+        yield tchannel.call(
+            scheme=schemes.RAW,
+            service='server',
+            arg1='endpoint',
+            hostport=server.hostport,
+            timeout=0.02,
+        )
+
+    # timeout is greater than sleep, should get resp
+    yield tchannel.call(
+        scheme=schemes.RAW,
+        service='server',
+        arg1='endpoint',
+        hostport=server.hostport,
+        timeout=1,
+    )
 
 
 def test_uninitialized_tchannel_is_fork_safe():

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -115,7 +115,7 @@ def test_timeout_should_raise_timeout_error():
 
     tchannel = TChannel(name='client')
 
-    # timeout is less than sleep, should get error
+    # timeout is less than server, should timeout
     with pytest.raises(TimeoutError):
         yield tchannel.call(
             scheme=schemes.RAW,
@@ -125,7 +125,7 @@ def test_timeout_should_raise_timeout_error():
             timeout=0.02,
         )
 
-    # timeout is greater than sleep, should get resp
+    # timeout is more than server, should not timeout
     yield tchannel.raw(
         service='server',
         endpoint='endpoint',


### PR DESCRIPTION
- update docs to show timeouts as seconds
- create integration test verifying timeout
- update default timeout to be 30 seconds, not 16 minutes