### PR TITLE
For VCR, use module.hostport to set the hostport

### DIFF
--- a/tchannel/testing/vcr/config.py
+++ b/tchannel/testing/vcr/config.py
@@ -25,9 +25,9 @@ import inspect
 import wrapt
 import sys
 
+from . import proxy
 from .cassette import Cassette
 from .patch import Patcher, force_reset
-from .proxy import VCRProxy
 from .server import VCRProxyService
 
 
@@ -53,10 +53,8 @@ class _CassetteContext(object):
         # TODO Maybe instead of using this instance of the TChannel client, we
         # should use the one being patched to make the requests?
 
-        # Need a better way to set hostport after loading!!
-        VCRProxy._module.hostport = server.hostport
-
-        self._exit_stack.enter_context(Patcher(VCRProxy))
+        proxy.hostport = server.hostport
+        self._exit_stack.enter_context(Patcher(proxy.VCRProxy))
 
         return cassette
 

--- a/tests/testing/vcr/test_server.py
+++ b/tests/testing/vcr/test_server.py
@@ -62,7 +62,7 @@ def vcr_service(cassette, unpatch, io_loop):
 
 @pytest.fixture
 def client(vcr_service):
-    proxy.VCRProxy._module.hostport = vcr_service.hostport
+    proxy.hostport = vcr_service.hostport
     return proxy.VCRProxy
 
 


### PR DESCRIPTION
    m = thrift.load(..)
    m.hostport = foo

Is the same as

    m = thrift.load(..)
    m.SomeService._module.hostport = foo

Because `m.SomeService._module` is `m`.

@blampe @breerly @junchaowu 