### PR TITLE
Fix BadYieldError and make tornado.TChannel.close not a coroutine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changes by Version
   'body', etc. See ``tchannel.testing.vcr.use_cassette``.
 - Removed ``tchannel.testing.data`` module.
 - Changed minimum required version of Tornado to 4.2.
+- ``tchannel.tornado.TChannel.close`` is no longer a coroutine.
 - **BREAKING** - headers for JSON handlers are not longer JSON blobs but are
   instead maps of strings to strings. This mirrors behavior for Thrift
   handlers.

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -187,14 +187,13 @@ class TChannel(object):
     def closed(self):
         return self._state == State.closed
 
-    @tornado.gen.coroutine
     def close(self):
         if self._state in [State.closed, State.closing]:
-            raise tornado.gen.Return(None)
+            return
 
         self._state = State.closing
         try:
-            yield self.peers.clear()
+            self.peers.clear()
         finally:
             self._state = State.closed
 

--- a/tests/tornado/test_tchannel.py
+++ b/tests/tornado/test_tchannel.py
@@ -70,3 +70,9 @@ def test_should_error_if_call_listen_twice(tchannel):
 
     with pytest.raises(AlreadyListeningError):
         tchannel.listen()
+
+
+def test_close_does_not_raise():
+    s = TChannel(name='test')
+    s.listen()
+    s.close()


### PR DESCRIPTION
`yield PeerGroup.clear()` was causing a BadYieldError because
`PeerGroup.clear` is no longer a coroutine.

@blampe @breerly @junchaowu 