### PR TITLE
add code to trigger after_send_error event

### DIFF
--- a/tchannel/errors.py
+++ b/tchannel/errors.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 
+from tchannel.zipkin.trace import Trace
+
 
 #: The request timed out.
 TIMEOUT = 0x01
@@ -77,7 +79,7 @@ class TChannelError(Exception):
         tracing=None,
     ):
         super(TChannelError, self).__init__(description)
-        self.tracing = tracing
+        self.tracing = tracing or Trace()
         self.id = id
         self.description = description
 

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -474,13 +474,12 @@ class TornadoConnection(object):
         """Convenience method for writing Error frames up the wire.
 
         :param error:
-            TChannel Error.
+            TChannel Error. :py:class`tchannel.errors.TChannelError`.
         """
 
         error_message = build_raw_error_message(error)
         write_future = self._write(error_message)
-        tornado.ioloop.IOLoop.current().add_future(
-            write_future,
+        write_future.add_done_callback(
             lambda f: self.tchannel.event_emitter.fire(
                 EventType.after_send_error,
                 error,

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -149,10 +149,10 @@ class RequestDispatcher(object):
         if request.endpoint in self.handlers and requested_as != expected_as:
             connection.send_error(BadRequestError(
                 description=(
-                    "Your serialization was '%s' but the server expected '%s'"
+                    "Server expected a '%s' but request is '%s'"
                     % (
-                        requested_as,
                         expected_as,
+                        requested_as,
                     )
                 ),
                 id=request.id,
@@ -226,7 +226,7 @@ class RequestDispatcher(object):
             e.id = request.id
             connection.send_error(e)
         except Exception as e:
-            log.exception("Unexpected Error: {0}".format(e.message))
+            log.exception("Unexpected Error: '%s'" % e.message)
 
             error = UnexpectedError(
                 description='An unexpected error occurred from the handler',

--- a/tchannel/tornado/message_factory.py
+++ b/tchannel/tornado/message_factory.py
@@ -52,6 +52,7 @@ log = logging.getLogger('tchannel')
 def build_raw_error_message(protocol_exception):
     """build protocol level error message based on Error object"""
     message = ErrorMessage(
+        id=protocol_exception.id,
         code=protocol_exception.code,
         tracing=Tracing(
             protocol_exception.tracing.span_id,
@@ -281,7 +282,9 @@ class MessageFactory(object):
             if context is None:
                 # missing call msg before continue msg
                 raise FatalProtocolError(
-                    "missing call message after receiving continue message")
+                    "missing call message after receiving continue message",
+                    message.id,
+                )
 
             # find the incompleted stream
             dst = 0
@@ -388,7 +391,10 @@ class MessageFactory(object):
                 self.in_checksum.pop(message.id)
         else:
             self.in_checksum.pop(message.id, None)
-            raise InvalidChecksumError("Checksum does not match!")
+            raise InvalidChecksumError(
+                description="Checksum does not match!",
+                id=message.id,
+            )
 
     @staticmethod
     def close_argstream(request, num):
@@ -408,7 +414,9 @@ class MessageFactory(object):
         if reqres is None:
             # missing call msg before continue msg
             raise FatalProtocolError(
-                "missing call message after receiving continue message")
+                "missing call message after receiving continue message",
+                id=protocol_error.id,
+            )
 
         # find the incompleted stream
         dst = 0

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -40,11 +40,7 @@ from tchannel.tornado.stream import InMemStream
 @tornado.gen.coroutine
 def handler_error(request, response):
     yield tornado.gen.sleep(0.01)
-    response.connection.send_error(
-        ErrorCode.busy,
-        "retry",
-        response.id,
-    )
+    response.connection.send_error(BusyError("retry", request.id))
     # stop normal response streams
     response.set_exception(TChannelError("stop stream"))
 

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -119,7 +119,7 @@ def test_retry_on_error_fail():
                 headers={
                     're': retry.CONNECTION_ERROR_AND_TIMEOUT
                 },
-                ttl=0.001,
+                ttl=1,
                 retry_limit=2,
             )
 

--- a/tests/integration/test_retry.py
+++ b/tests/integration/test_retry.py
@@ -119,7 +119,7 @@ def test_retry_on_error_fail():
                 headers={
                     're': retry.CONNECTION_ERROR_AND_TIMEOUT
                 },
-                ttl=0.02,
+                ttl=0.001,
                 retry_limit=2,
             )
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -82,7 +82,6 @@ def test_after_send_error_event_called():
                 hostport=tchannel.hostport,
                 timeout=0.02,
             )
-
         mock_fire.assert_any_call(
             mock.ANY, EventType.after_send_error, mock.ANY,
         )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -20,9 +20,13 @@
 
 from __future__ import absolute_import
 
+import mock
 import pytest
 from mock import MagicMock
 
+from tchannel import TChannel
+from tchannel import schemes
+from tchannel.errors import BadRequestError
 from tchannel.event import EventEmitter
 from tchannel.event import EventHook
 from tchannel.event import EventRegistrar
@@ -60,3 +64,25 @@ def test_decorator_registration():
 
     assert called[0] is True
     assert called[1] is True
+
+
+@pytest.mark.gen_test
+def test_after_send_error_event_called():
+    tchannel = TChannel('test')
+    tchannel.listen()
+    with mock.patch(
+        'tchannel.event.EventEmitter.fire', autospec=True,
+    ) as mock_fire:
+        mock_fire.return_value = None
+        with pytest.raises(BadRequestError):
+            yield tchannel.call(
+                scheme=schemes.RAW,
+                service='test',
+                arg1='endpoint',
+                hostport=tchannel.hostport,
+                timeout=0.02,
+            )
+
+        mock_fire.assert_any_call(
+            mock.ANY, EventType.after_send_error, mock.ANY,
+        )

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from __future__ import absolute_import
 
 import pytest

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+
+import pytest
+
+from tchannel import TChannel, schemes
+from tchannel.errors import BadRequestError
+from tchannel.event import EventHook
+
+
+@pytest.mark.gen_test
+def test_error_trace():
+    tchannel = TChannel('test')
+
+    class ErrorEventHook(EventHook):
+        def __init__(self):
+            self.request_trace = None
+            self.error_trace = None
+
+        def before_receive_request(self, request):
+            self.request_trace = request.tracing
+
+        def after_send_error(self, error):
+            self.error_trace = error.tracing
+
+    hook = ErrorEventHook()
+    tchannel.hooks.register(hook)
+
+    tchannel.listen()
+
+    with pytest.raises(BadRequestError):
+        yield tchannel.call(
+            scheme=schemes.RAW,
+            service='test',
+            arg1='endpoint',
+            hostport=tchannel.hostport,
+            timeout=0.02,
+        )
+
+    assert hook.error_trace
+    assert hook.request_trace
+    assert hook.error_trace == hook.request_trace

--- a/tests/tornado/test_dispatch.py
+++ b/tests/tornado/test_dispatch.py
@@ -68,7 +68,7 @@ def test_handle_call(dispatcher, req, connection):
 def test_default_fallback_behavior(dispatcher, req, connection):
     """Undefined endpoints return 'Bad Request' errors."""
     yield dispatcher.handle_call(req, connection)
-    assert connection.send_error.call_args[0][0] == ErrorCode.bad_request
+    assert connection.send_error.call_args[0][0].code == ErrorCode.bad_request
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
Somehow the after_send_error event is missing from current master. Add it.
Add tracing to the error too.