### PR TITLE
Add hostport argument to ThriftArgScheme.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Changes by Version
   handlers.
 - Fixed bug that caused server to continue listening for incoming connections
   despite closing the channel.
+- Explicit destinations for ``ThriftArgScheme`` may now be specified on a
+  per-request basis by using the ``hostport`` keyword argument.
+
 
 0.17.9 (2015-10-15)
 -------------------

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -73,8 +73,8 @@ class JsonArgScheme(object):
             Endpoint to call on service.
         :param string body:
             A raw body to provide to the endpoint.
-        :param string headers:
-            A raw headers block to provide to the endpoint.
+        :param dict headers:
+            Dictionary of header key-value pairs.
         :param float timeout:
             How long to wait (in seconds) before raising a ``TimeoutError`` -
             this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -73,11 +73,38 @@ class ThriftArgScheme(object):
         request,
         headers=None,
         timeout=None,
+        hostport=None,
         retry_on=None,
         retry_limit=None,
         shard_key=None,
         trace=None,
     ):
+        """Make a Thrift TChannel request.
+
+        Returns a ``Response`` containing the return value of the Thrift
+        call (if any). If the remote server responded with a Thrift exception,
+        that exception is raised.
+
+        :param string request:
+            Request obtained by calling a method on service objects generated
+            by :py:func:`tchannel.thrift.load`.
+        :param dict headers:
+            Dictionary of header key-value pairs.
+        :param float timeout:
+            How long to wait (in seconds) before raising a ``TimeoutError`` -
+            this defaults to ``tchannel.glossary.DEFAULT_TIMEOUT``.
+        :param string hostport:
+            A 'host:port' value to use when making a request directly to a
+            TChannel service, bypassing Hyperbahn. This value takes precedence
+            over the ``hostport`` specified to
+            :py:func:`tchannel.thrift.load`.
+        :param string retry_on:
+            What events to retry on - valid values can be found in
+            ``tchannel.retry``.
+        :param string retry_limit:
+            How many times to retry before
+        :rtype: Response
+        """
         if not headers:
             headers = {}
 
@@ -104,7 +131,7 @@ class ThriftArgScheme(object):
             timeout=timeout,
             retry_on=retry_on,
             retry_limit=retry_limit,
-            hostport=request.hostport,
+            hostport=hostport or request.hostport,
             shard_key=shard_key,
             trace=trace,
         )

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -73,11 +73,11 @@ class ThriftArgScheme(object):
         request,
         headers=None,
         timeout=None,
-        hostport=None,
         retry_on=None,
         retry_limit=None,
         shard_key=None,
         trace=None,
+        hostport=None,
     ):
         """Make a Thrift TChannel request.
 

--- a/tchannel/testing/vcr/config.py
+++ b/tchannel/testing/vcr/config.py
@@ -27,7 +27,6 @@ import sys
 
 from .cassette import Cassette
 from .patch import Patcher, force_reset
-from .proxy import VCRProxy
 from .server import VCRProxyService
 
 
@@ -58,10 +57,7 @@ class _CassetteContext(object):
         # TODO Maybe instead of using this instance of the TChannel client, we
         # should use the one being patched to make the requests?
 
-        # Need a better way to set hostport after loading!!
-        VCRProxy._module.hostport = server.hostport
-
-        self._exit_stack.enter_context(Patcher(VCRProxy))
+        self._exit_stack.enter_context(Patcher(server.hostport))
 
         return cassette
 

--- a/tests/testing/vcr/test_patcher.py
+++ b/tests/testing/vcr/test_patcher.py
@@ -20,34 +20,26 @@
 
 from __future__ import absolute_import
 
-import pytest
-
 from tchannel.tornado import TChannel
-from tchannel.testing.vcr import proxy
 from tchannel.testing.vcr.patch import Patcher
 from tchannel.testing.vcr.patch import PatchedClientOperation
 
 
-@pytest.fixture
-def vcr_client():
-    return proxy.VCRProxy
-
-
-def test_patching_as_context_manager(vcr_client):
+def test_patching_as_context_manager():
     chan = TChannel('client')
-    with Patcher(vcr_client):
+    with Patcher('localhost:4040'):
         ops = chan.request(service='foo')
         assert isinstance(ops, PatchedClientOperation)
-        assert ops.vcr_client is vcr_client
+        assert ops.vcr_hostport == 'localhost:4040'
 
 
-def test_patching_as_decorator(vcr_client):
+def test_patching_as_decorator():
     chan = TChannel('client')
 
-    @Patcher(vcr_client)
+    @Patcher('localhost:4040')
     def f():
         ops = chan.request(service='foo')
         assert isinstance(ops, PatchedClientOperation)
-        assert ops.vcr_client is vcr_client
+        assert ops.vcr_hostport == 'localhost:4040'
 
     f()


### PR DESCRIPTION
Update VCR's use of ThriftArgScheme to use the hostport argument.

Resolves #220.