### PR TITLE
TChannel.close() should actually stop listening for connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,8 @@ Changes by Version
 - **BREAKING** - headers for JSON handlers are not longer JSON blobs but are
   instead maps of strings to strings. This mirrors behavior for Thrift
   handlers.
-
+- Fixed bug that caused server to continue listening for incoming connections
+  despite closing the channel.
 
 0.17.9 (2015-10-15)
 -------------------

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -194,6 +194,8 @@ class TChannel(object):
         self._state = State.closing
         try:
             self.peers.clear()
+            if self._server:
+                self._server.stop()
         finally:
             self._state = State.closed
 

--- a/tests/tornado/test_tchannel.py
+++ b/tests/tornado/test_tchannel.py
@@ -21,6 +21,7 @@
 from __future__ import absolute_import
 
 import pytest
+import socket
 
 from tchannel.errors import AlreadyListeningError
 from tchannel.tornado import TChannel
@@ -72,7 +73,22 @@ def test_should_error_if_call_listen_twice(tchannel):
         tchannel.listen()
 
 
-def test_close_does_not_raise():
-    s = TChannel(name='test')
-    s.listen()
-    s.close()
+def test_close_stops_listening():
+    server = TChannel(name='server')
+    server.listen()
+
+    host, port = server.hostport.rsplit(':', 1)
+    port = int(port)
+
+    # Can connect
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((host, port))
+    sock.close()
+
+    server.close()
+
+    # Can't connect
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    with pytest.raises(socket.error):
+        sock.connect((host, port))


### PR DESCRIPTION
@blampe @breerly @junchaowu 