### PR TITLE
Improve peer selection performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Changes by Version
 - **BREAKING** - Removed ``tchannel.thrift_request_builder`` as
   planned in 0.18.
 - Reduced Zipkin submission failures to warnings.
+- Improved performance of peer selection logic.
+- Fixed a bug which caused the message ID and tracing for incoming error frames
+  to be ignored.
+- Prefer using incoming connections on peers instead of outgoing connections.
 
 
 0.18.0 (2015-10-20)

--- a/benchmarks/test_peer_selection.py
+++ b/benchmarks/test_peer_selection.py
@@ -18,7 +18,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import absolute_import, unicode_literals, print_function
+from __future__ import (
+    absolute_import, unicode_literals, print_function, division
+)
 
 import mock
 import random

--- a/benchmarks/test_peer_selection.py
+++ b/benchmarks/test_peer_selection.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import absolute_import, unicode_literals, print_function
+
+import mock
+import random
+
+from tchannel.tornado.peer import (
+    Peer as _Peer,
+    PeerGroup as _PeerGroup,
+)
+
+
+NUM_PEERS = 1000
+
+
+class FakeConnection(object):
+
+    def __init__(self, hostport):
+        self.hostport = hostport
+        self.closed = False
+
+    @classmethod
+    def outgoing(cls, hostport, process_name=None, serve_hostport=None,
+                 handler=None, tchannel=None):
+        return FakeConnection(hostport)
+
+    def add_done_callback(self, cb):
+        return cb(self)
+
+    def exception(self):
+        return None
+
+    def result(self):
+        return self
+
+
+class Peer(_Peer):
+    connection_class = FakeConnection
+
+
+class PeerGroup(_PeerGroup):
+    peer_class = Peer
+
+
+def hostport():
+    host = b'.'.join(bytes(random.randint(0, 255)) for i in xrange(4))
+    port = random.randint(1000, 30000)
+    return b'%s:%d' % (host, port)
+
+
+def peer(tchannel, hostport):
+    return Peer(tchannel, hostport)
+
+
+def test_choose(benchmark):
+    tchannel = mock.MagicMock()
+    group = PeerGroup(tchannel)
+
+    # Register 1000 random peers
+    for i in xrange(NUM_PEERS):
+        peer = group.get(hostport())
+
+    connected_peers = set()
+
+    # Add one outgoing connection to a random peer.
+    peer = group.peers[random.randint(0, NUM_PEERS-1)]
+    peer.connect()
+    connected_peers.add(peer.hostport)
+
+    # Add incoming connections from 50 random peers.
+    while len(connected_peers) < 50:
+        peer = group.peers[random.randint(0, NUM_PEERS-1)]
+        if peer.hostport in connected_peers:
+            continue
+        peer.register_incoming(FakeConnection(peer.hostport))
+        connected_peers.add(peer.hostport)
+
+    benchmark(group.choose)

--- a/benchmarks/test_peer_selection.py
+++ b/benchmarks/test_peer_selection.py
@@ -52,6 +52,9 @@ class FakeConnection(object):
     def result(self):
         return self
 
+    def set_close_callback(self, cb):
+        pass
+
 
 class Peer(_Peer):
     connection_class = FakeConnection

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -36,7 +36,7 @@ if [[ ! -x "$LICENSE_EXEC" ]]; then
 	popd &>/dev/null
 fi
 
-for d in tchannel tests examples; do
+for d in tchannel tests benchmarks examples; do
 	pushd "$ROOT/$d" &>/dev/null
 	ensure_license
 	popd &>/dev/null

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,7 @@ pytest<2.8.0
 pytest-cov
 pytest-timeout
 pytest-tornado
+pytest-benchmark[histogram]==3.0.0rc1
 
 # Property based tests
 hypothesis-pytest==0.12.0

--- a/tchannel/testing/vcr/patch.py
+++ b/tchannel/testing/vcr/patch.py
@@ -59,15 +59,12 @@ class PatchedClientOperation(object):
         arg_scheme=None,
         retry=None,
         parent_tracing=None,
-        score_threshold=None,
     ):
         self.vcr_hostport = vcr_hostport
         self.hostport = hostport or ''
         self.service = service or ''
         self.arg_scheme = arg_scheme or schemes.DEFAULT
         self.original_tchannel = original_tchannel
-
-        # TODO what to do with retry, parent_tracing and score_threshold
 
     @gen.coroutine
     def send(self, arg1, arg2, arg3,

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -497,6 +497,7 @@ class TornadoConnection(object):
                 error,
             )
         )
+        return write_future
 
     def ping(self):
         return self._write(messages.PingRequestMessage())

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -237,6 +237,8 @@ class TornadoConnection(object):
                         error = TChannelError.from_code(
                             message.code,
                             description=message.description,
+                            id=message.id,
+                            tracing=message.tracing,
                         )
                         future.set_exception(error)
                     else:

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -109,11 +109,11 @@ class Peer(object):
         :return:
             A future containing a connection to this host.
         """
-        # Prefer recently created outgoing connections over everything else.
+        # Prefer incoming connections over outgoing connections.
         if self._connections:
-            # Last value is an outgoing connection
+            # First value is an incoming connection
             future = gen.Future()
-            future.set_result(self._connections[-1])
+            future.set_result(self._connections[0])
             return future
 
         if self._connecting:

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -188,7 +188,8 @@ class Peer(object):
         return len(self._connections) > 0
 
     def close(self):
-        for connection in self._connections:
+        for connection in list(self._connections):
+            # closing the connection will mutate the deque so create a copy
             connection.close()
 
 

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -45,6 +45,7 @@ from ..schemes import JSON
 from ..serializer.json import JsonSerializer
 from ..serializer.raw import RawSerializer
 from .connection import StreamConnection
+from .connection import INCOMING
 from .dispatch import RequestDispatcher
 from .peer import PeerGroup
 
@@ -401,7 +402,11 @@ class TChannelServer(tornado.tcpserver.TCPServer):
     def handle_stream(self, stream, address):
         log.debug("New incoming connection from %s:%d" % address)
 
-        conn = StreamConnection(connection=stream, tchannel=self.tchannel)
+        conn = StreamConnection(
+            connection=stream,
+            tchannel=self.tchannel,
+            direction=INCOMING,
+        )
 
         yield conn.expect_handshake(headers={
             'host_port': self.tchannel.hostport,

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 
 import mock
 import pytest
-import socket
 import tornado.ioloop
 import tornado.testing
 

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -20,11 +20,15 @@
 
 from __future__ import absolute_import
 
+import mock
 import pytest
+import socket
 import tornado.ioloop
 import tornado.testing
 
 from tchannel.messages import Types
+from tchannel import TChannel
+from tchannel.tornado.connection import StreamConnection
 
 
 def dummy_headers():
@@ -61,3 +65,19 @@ class ConnectionTestCase(tornado.testing.AsyncTestCase):
 
         pong = yield self.client.await()
         assert pong.message_type == Types.PING_RES
+
+
+@pytest.mark.gen_test
+def test_close_callback_is_called():
+    server = TChannel('server')
+    server.listen()
+
+    close_cb = mock.Mock()
+
+    conn = yield StreamConnection.outgoing(
+        server.hostport, tchannel=mock.MagicMock()
+    )
+    conn.set_close_callback(close_cb)
+
+    conn.close()
+    close_cb.assert_called_once_with()

--- a/tests/tornado/test_peer.py
+++ b/tests/tornado/test_peer.py
@@ -188,3 +188,21 @@ def test_peer_connection_failure_exhausted_peers():
 
     with pytest.raises(NoAvailablePeerError):
         yield client.raw('server', 'hello', 'foo')
+
+
+@pytest.mark.gen_test
+def test_peer_incoming_connections_are_preferred(request):
+    incoming = mock.MagicMock()
+    outgoing = mock.MagicMock()
+
+    peer = tpeer.Peer(mock.MagicMock(), 'localhost:4040')
+    with mock.patch(
+        'tchannel.tornado.connection.StreamConnection.outgoing'
+    ) as mock_outgoing:
+        mock_outgoing.return_value = gen.maybe_future(outgoing)
+        peer.connect()
+
+    assert (yield peer.connect()) is outgoing
+
+    peer.register_incoming(incoming)
+    assert (yield peer.connect()) is incoming


### PR DESCRIPTION
This PR contains a series of related commits. Feel free to review them all together or look at the commits separately.

Some notes regarding peer selection itself:

- Peer connections were previously managed in two separate deques which were concatenated together whenever all connections were needed. However, it turns out we always need all connections and rarely check the connection groups separately. So, peers now maintain a single connection list. Incoming connections are added on one side and outgoing on the other side. Connections know which direction they're in (incoming or outgoing) so we can still query based on direction when needed.
- For individual peers, we prefer to use incoming connections over outgoing connections (see also #205).
- Finally, for the actual peer selection logic, instead of assigning each peer a random score for *all* requests and then picking one of them, I changed the logic to pick one of the peers which we have a connection to at random (so just one `randint` call). If we don't have any existing connections, just pick a peer at random. This logic is exactly the same as before but with less complication. We can improve upon this logic based on discussion next/later.

Oh and one more thing: To write the benchmark, I had to change the order in which PeerGroup vs Peer is defined. That's in the first commit ('Add benchmark [..]'). So look at  the 'Optimize linear peer selection logic' commit to see what changes were made to PeerGroup itself. Or check https://github.com/uber/tchannel-python/compare/67ed184f8901c2e69aea6d5a61a0c2e876a40fcc...peer_selection for a diff ignoring that commit.

Performance improvements:
![image](https://cloud.githubusercontent.com/assets/41730/10745117/21272e7a-7bfc-11e5-9311-f2c3673ccec2.png)

Changelog incoming. 

CC @blampe @breerly @junchaowu 