### PR TITLE
Support thriftrw 1.0 and pre-1.0 versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,10 @@ sudo: false
 #
 language: python
 env:
-    - TOX_ENV=py27
-    - TOX_ENV=pypy
+    - TOX_ENV=py27-thriftrw05
+    - TOX_ENV=py27-thriftrw10
+    - TOX_ENV=pypy-thriftrw05
+    - TOX_ENV=pypy-thriftrw10
     - TOX_ENV=cover
     - TOX_ENV=flake8
     - TOX_ENV=docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.20.0 (unreleased)
 -------------------
 
-- **BREAKING** - At least thriftrw 1.0 is now required.
+- Support thriftrw 1.0.
 - Drop explicit dependency on the ``futures`` library.
 
 

--- a/UPGRADE.rst
+++ b/UPGRADE.rst
@@ -9,22 +9,7 @@ what broke and how to safely migrate to newer versions.
 From 0.19 to 0.20
 -----------------
 
-- At least ``thriftrw`` 1.0 is now required. If you had an explicit dependency
-  on thriftrw, please update the constraints to lock on the major version.
-
-  Before::
-
-      thriftrw>=0.5,<0.6
-
-  After::
-
-      thriftrw>=1,<2
-
-  If you see an error similar to::
-
-      AttributeError: 'module' object has no attribute '__services__'
-
-  It means that you're on a version of ``thriftrw`` less than 1.0.
+- No breaking changes.
 
 
 From 0.18 to 0.19

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'tornado>=4.2,<5',
 
         # tchannel deps
-        'thriftrw>=1,<2',
+        'thriftrw>=0.4,<2',
         'threadloop>=1,<2',
     ],
     extras_require={

--- a/tchannel/thrift/rw.py
+++ b/tchannel/thrift/rw.py
@@ -179,7 +179,12 @@ class TChannelThriftModule(types.ModuleType):
 
         self._module = module
 
-        for service_cls in self._module.__services__:
+        services = getattr(self._module, '__services__', None)
+        if services is None:
+            # thriftrw <1.0
+            services = getattr(self._module, 'services')
+
+        for service_cls in services:
             name = service_cls.service_spec.name
             setattr(self, name, Service(service_cls, self))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,33 @@
 [tox]
-envlist = py27,cover,flake8,pypy,docs
+envlist = {py27,pypy}-thriftrw{05,10},cover,flake8,docs
+
 
 [testenv]
 deps =
   -rrequirements-test.txt
+  thriftrw05: thriftrw>=0.5,<0.6
+  thriftrw10: thriftrw>=1,<2
 whitelist_externals = /usr/bin/make
 commands =
   py.test --cov-report=term-missing {posargs}
+basepython =
+    py27: python2.7
+    pypy: pypy
+
 
 [testenv:flake8]
+basepython = python
 commands = make lint
 
+
 [testenv:cover]
+basepython = python
 commands =
   py.test --cov tchannel --cov-report=xml --cov-report=term-missing {posargs}
 
+
 [testenv:docs]
+basepython = python
 deps =
   -rrequirements-docs.txt
   tchannel[vcr]


### PR DESCRIPTION
Added tox tests for thriftrw 0.5 and 1.0.

Also, fixed the pypy basepython configuration for tox.

---

We can drop this when we hit 1.0 and require thriftrw >= 1.0