### PR TITLE
Change tchannel.thrift.register to return the unchanged handler.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,10 @@ Changes by Version
   ``tchannel.sync.thrift.client_for`` as planned in 0.18.
 - **BREAKING** - Removed ``tchannel.thrift_request_builder`` as
   planned in 0.18.
-- **BREAKING** - ``tchannel.thrift.register`` returns the wrapped function
-  as-is. This allows calling the function diretly for unit tests.
+- **BREAKING** - Support unit testing endpoints by calling the handler
+  functions directly. This is enabled by changing ``tchannel.thrift.register``
+  to return the registered function unmodified. See Upgrade Guide for more
+  details.
 - Reduced Zipkin submission failures to warnings.
 - Limit the size of arg1 to 16KB.
 - Fix bug which prevented requests from being retried if the candidate

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Changes by Version
   ``tchannel.sync.thrift.client_for`` as planned in 0.18.
 - **BREAKING** - Removed ``tchannel.thrift_request_builder`` as
   planned in 0.18.
+- **BREAKING** - ``tchannel.thrift.register`` returns the wrapped function
+  as-is. This allows calling the function diretly for unit tests.
 - Reduced Zipkin submission failures to warnings.
 - Limit the size of arg1 to 16KB.
 - Fix bug which prevented requests from being retried if the candidate

--- a/tchannel/thrift/rw.py
+++ b/tchannel/thrift/rw.py
@@ -307,10 +307,9 @@ def register(dispatcher, service, handler=None, method=None):
         )
         assert not function.oneway
 
-        handler = build_handler(function, handler)
         dispatcher.register(
             function.endpoint,
-            handler,
+            build_handler(function, handler),
             ThriftSerializer(service._module, function._request_cls),
             ThriftSerializer(service._module, function._response_cls),
         )

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -1045,7 +1045,7 @@ def test_exception_status_code_is_set(server, ThriftTest, server_ttypes):
 # as if they weren't registered at all
 
 
-def make_request(**kwargs):
+def body(**kwargs):
     """Constructs fake Request objects.
 
     The ``_headers`` kwarg may be used to set the header on the Request
@@ -1053,10 +1053,7 @@ def make_request(**kwargs):
     """
     request = mock.Mock()
     for k, v in kwargs.items():
-        if k == '_headers':
-            request.headers = v
-        else:
-            setattr(request.body, k, v)
+        setattr(request, k, v)
     return request
 
 
@@ -1066,7 +1063,7 @@ def test_void_call_directly(server, ThriftTest):
     def testVoid(request):
         pass
 
-    resp = testVoid(make_request())
+    resp = testVoid(Request())
     assert resp is None
 
 
@@ -1077,7 +1074,7 @@ def test_void_with_headers_call_directly(server, ThriftTest):
         assert request.headers == {'req': 'header'}
         return Response(headers={'resp': 'header'})
 
-    resp = testVoid(make_request(_headers={'req': 'header'}))
+    resp = testVoid(Request(headers={'req': 'header'}))
     assert resp.headers == {'resp': 'header'}
     assert resp.body is None
 
@@ -1088,7 +1085,7 @@ def test_non_void_call_directly(server, ThriftTest):
     def testString(request):
         return request.body.thing
 
-    resp = testString(make_request(thing='howdy'))
+    resp = testString(Request(body=body(thing='howdy')))
     assert resp == 'howdy'
 
 
@@ -1109,9 +1106,9 @@ def test_non_void_with_headers_cal_directly(
         )
 
     resp = testStruct(
-        make_request(
-            _headers={'req': 'header'},
-            thing=client_ttypes.Xtruct("req string"),
+        Request(
+            headers={'req': 'header'},
+            body=body(thing=client_ttypes.Xtruct("req string")),
         )
     )
 

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 import pytest
 from tornado import gen
 
@@ -1037,3 +1038,83 @@ def test_exception_status_code_is_set(server, ThriftTest, server_ttypes):
     )
 
     assert 1 == res.status_code
+
+
+##############################################################################
+# Calling registered functions directly should be equivalent to calling them
+# as if they weren't registered at all
+
+
+def make_request(**kwargs):
+    """Constructs fake Request objects.
+
+    The ``_headers`` kwarg may be used to set the header on the Request
+    object.
+    """
+    request = mock.Mock()
+    for k, v in kwargs.items():
+        if k == '_headers':
+            request.headers = v
+        else:
+            setattr(request.body, k, v)
+    return request
+
+
+def test_void_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testVoid(request):
+        pass
+
+    resp = testVoid(make_request())
+    assert resp is None
+
+
+def test_void_with_headers_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testVoid(request):
+        assert request.headers == {'req': 'header'}
+        return Response(headers={'resp': 'header'})
+
+    resp = testVoid(make_request(_headers={'req': 'header'}))
+    assert resp.headers == {'resp': 'header'}
+    assert resp.body is None
+
+
+def test_non_void_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testString(request):
+        return request.body.thing
+
+    resp = testString(make_request(thing='howdy'))
+    assert resp == 'howdy'
+
+
+def test_non_void_with_headers_cal_directly(
+    server, service, ThriftTest, server_ttypes, client_ttypes
+):
+
+    # Given this test server:
+
+    @server.thrift.register(ThriftTest)
+    def testStruct(request):
+        assert request.headers == {'req': 'header'}
+        assert request.body.thing.string_thing == 'req string'
+
+        return Response(
+            server_ttypes.Xtruct(string_thing="resp string"),
+            headers={'resp': 'header'},
+        )
+
+    resp = testStruct(
+        make_request(
+            _headers={'req': 'header'},
+            thing=client_ttypes.Xtruct("req string"),
+        )
+    )
+
+    assert isinstance(resp, Response)
+    assert resp.headers == {'resp': 'header'}
+    assert resp.body == client_ttypes.Xtruct("resp string")


### PR DESCRIPTION
This allows calling the handler directly with a Request object in unit tests.

Resolves #300.

Users still have to construct Request objects manually and don't usually have
access to the request/response class for the method so #144 is still open, but
this takes one piece of surprising/annoying behavior away.