### PR TITLE
Add test util to directly test requests to user's handler

### DIFF
--- a/tchannel/testing/dispatch.py
+++ b/tchannel/testing/dispatch.py
@@ -1,0 +1,43 @@
+from __future__ import absolute_import
+
+from tornado import gen
+
+from ..response import response_from_mixed
+
+
+@gen.coroutine
+def handle(tchannel, request):
+    """Test util function to have tchannel instance to take predefined request
+    object.
+
+    .. code-block:: python
+        tchannel = TChannel('example')
+
+        @tchannel.raw.register
+        @gen.coroutine
+        def testString(request):
+            return Response('resp', headers={'resp': 'header'})
+
+        request = Request(
+            body="body",
+            headers={},
+            transport={},
+            endpoint="endpoint",
+        )
+
+        response = yield handle(tchannel, request)
+
+    :param tchannel:
+        An instance of ``tchannel.TChannel`` that has registered endpoints.
+
+    :param request:
+        An instance of ``tchannel.Request``.
+
+    :return
+        Return the ``tchannel.Response`` from User's endpoint.
+    """
+    resp = yield gen.maybe_future(tchannel._dep_tchannel._handler.get_endpoint(
+        request.endpoint
+    ).endpoint(request))
+
+    raise gen.Return(response_from_mixed(resp))

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -151,10 +151,7 @@ class RequestDispatcher(object):
         request.tracing.name = request.endpoint
         tchannel.event_emitter.fire(EventType.before_receive_request, request)
 
-        handler = self.handlers.get(request.endpoint)
-
-        if handler is None:
-            handler = self.handlers[self.FALLBACK]
+        handler = self.get_endpoint(request.endpoint)
 
         requested_as = request.headers.get('as', None)
         expected_as = handler.req_serializer.name
@@ -252,6 +249,14 @@ class RequestDispatcher(object):
             tchannel.event_emitter.fire(EventType.on_exception, request, error)
 
         raise gen.Return(response)
+
+    def get_endpoint(self, name):
+        handler = self.handlers.get(name)
+
+        if handler is None:
+            handler = self.handlers[self.FALLBACK]
+
+        return handler
 
     def register(
             self,

--- a/tests/testing/test_dispatch.py
+++ b/tests/testing/test_dispatch.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import
+
+import pytest
+
+from tchannel import TChannel, Request
+from tchannel.errors import BadRequestError
+from tchannel.testing.dispatch import handle
+
+
+@pytest.fixture
+def server():
+    tchannel = TChannel('test_server')
+
+    @tchannel.raw.register
+    def hello(request):
+        return request.body + " world"
+
+    return tchannel
+
+
+@pytest.mark.gen_test
+def test_handle_success(server):
+    request = Request(
+        body="hello",
+        endpoint="hello",
+    )
+    response = yield handle(server, request)
+    assert response.body == request.body + " world"
+
+
+@pytest.mark.gen_test
+def test_handle_unknown_endpoint(server):
+    request = Request(
+        body="hello",
+        endpoint="xxxxx",
+    )
+
+    with pytest.raises(BadRequestError):
+        yield handle(server, request)


### PR DESCRIPTION
This test util will take user's predefined request to find the endpoint and return response.
@blampe @abhinav 