### PR TITLE
Add custom peer heap class

### DIFF
--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -40,7 +40,8 @@ class HeapOperation(object):
 def init(h):
     # heapify
     n = h.size()
-    for i in six.moves.range(int(math.floor(n/2)) - 1, -1):
+    for i in six.moves.range(int(math.floor(n/2)) - 1, -1, -1):
+        print i
         down(h, i, n)
 
 

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -38,6 +38,7 @@ class HeapOperation(object):
 
 
 def init(h):
+    """Initialize existing object into the heap."""
     # heapify
     n = h.size()
     for i in six.moves.range(int(math.floor(n/2)) - 1, -1, -1):
@@ -45,11 +46,13 @@ def init(h):
 
 
 def push(h, x):
+    """Push a new value into heap."""
     h.push(x)
     up(h, h.size()-1)
 
 
 def pop(h):
+    """Pop the heap value from the heap."""
     n = h.size() - 1
     h.swap(0, n)
     down(h, 0, n)
@@ -57,6 +60,7 @@ def pop(h):
 
 
 def remove(h, i):
+    """Remove the item at position i of the heap."""
     n = h.size() - 1
     if n != i:
         h.swap(i, n)
@@ -67,6 +71,7 @@ def remove(h, i):
 
 
 def fix(h, i):
+    """Rearrange the heap after the item at position i got updated."""
     down(h, i, h.size())
     up(h, i)
 

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from __future__ import absolute_import
 from __future__ import division
 

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -6,7 +6,12 @@ import six
 
 
 class HeapOperation(object):
-    def cmp(self, i, j):
+    """HeapOperation defines the interface on how to manipulate the heap.
+    Any extension of heap class should implement all the heap operations in
+    order to have complete heap functions.
+    """
+
+    def less(self, i, j):
         """Compare the items in position i and j of the heap.
 
         :param i: the first item's position of the heap list
@@ -27,28 +32,32 @@ class HeapOperation(object):
         """swap items between position i and j of the heap"""
         raise NotImplementedError()
 
+    def size(self):
+        """Return length of the heap."""
+        raise NotImplementedError()
+
 
 def init(h):
     # heapify
-    n = len(h)
+    n = h.size()
     for i in six.moves.range(int(math.floor(n/2)) - 1, -1):
         down(h, i, n)
 
 
 def push(h, x):
     h.push(x)
-    up(h, len(h)-1)
+    up(h, h.size()-1)
 
 
 def pop(h):
-    n = len(h) - 1
+    n = h.size() - 1
     h.swap(0, n)
     down(h, 0, n)
     return h.pop()
 
 
 def remove(h, i):
-    n = len(h) - 1
+    n = h.size() - 1
     if n != i:
         h.swap(i, n)
         down(h, i, n)
@@ -58,14 +67,14 @@ def remove(h, i):
 
 
 def fix(h, i):
-    down(h, i, len(h))
+    down(h, i, h.size())
     up(h, i)
 
 
 def up(h, child):
     while child > 0:
         parent = int(math.floor((child - 1) / 2))
-        if not h.cmp(child, parent):
+        if not h.less(child, parent):
             break
 
         h.swap(parent, child)
@@ -80,10 +89,10 @@ def down(h, parent, n):
 
         min_child = child1
         child2 = child1 + 1
-        if child2 < n and not h.cmp(child1, child2):
+        if child2 < n and not h.less(child1, child2):
             min_child = child2
 
-        if not h.cmp(min_child, parent):
+        if not h.less(min_child, parent):
             break
 
         h.swap(parent, min_child)

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -41,7 +41,6 @@ def init(h):
     # heapify
     n = h.size()
     for i in six.moves.range(int(math.floor(n/2)) - 1, -1, -1):
-        print i
         down(h, i, n)
 
 

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -11,7 +11,7 @@ class HeapOperation(object):
     order to have complete heap functions.
     """
 
-    def less(self, i, j):
+    def lt(self, i, j):
         """Compare the items in position i and j of the heap.
 
         :param i: the first item's position of the heap list
@@ -74,7 +74,7 @@ def fix(h, i):
 def up(h, child):
     while child > 0:
         parent = int(math.floor((child - 1) / 2))
-        if not h.less(child, parent):
+        if not h.lt(child, parent):
             break
 
         h.swap(parent, child)
@@ -89,10 +89,10 @@ def down(h, parent, n):
 
         min_child = child1
         child2 = child1 + 1
-        if child2 < n and not h.less(child1, child2):
+        if child2 < n and not h.lt(child1, child2):
             min_child = child2
 
-        if not h.less(min_child, parent):
+        if not h.lt(min_child, parent):
             break
 
         h.swap(parent, min_child)

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -1,4 +1,8 @@
 from __future__ import absolute_import
+from __future__ import division
+
+import math
+import six
 
 
 class HeapOperation(object):
@@ -27,7 +31,7 @@ class HeapOperation(object):
 def init(h):
     # heapify
     n = len(h)
-    for i in range(n/2 - 1, -1):
+    for i in six.moves.range(int(math.floor(n/2)) - 1, -1):
         down(h, i, n)
 
 
@@ -58,29 +62,29 @@ def fix(h, i):
     up(h, i)
 
 
-def up(h, j):
-    while j > 0:
-        i = (j - 1) / 2
-        if i == j or not h.cmp(j, i):
+def up(h, child):
+    while child > 0:
+        parent = int(math.floor((child - 1) / 2))
+        if not h.cmp(child, parent):
             break
 
-        h.swap(i, j)
-        j = i
+        h.swap(parent, child)
+        child = parent
 
 
-def down(h, i, n):
+def down(h, parent, n):
     while True:
-        j1 = 2*i + 1
-        if j1 >= n or j1 < 0:
+        child1 = 2 * parent + 1
+        if child1 >= n or child1 < 0:
             break
 
-        j = j1
-        j2 = j1 + 1
-        if j2 < n and not h.cmp(j1, j2):
-            j = j2
+        min_child = child1
+        child2 = child1 + 1
+        if child2 < n and not h.cmp(child1, child2):
+            min_child = child2
 
-        if not h.cmp(j, i):
+        if not h.cmp(min_child, parent):
             break
 
-        h.swap(i, j)
-        i = j
+        h.swap(parent, min_child)
+        parent = min_child

--- a/tchannel/container/heap.py
+++ b/tchannel/container/heap.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import
+
+
+class HeapOperation(object):
+    def cmp(self, i, j):
+        """Compare the items in position i and j of the heap.
+
+        :param i: the first item's position of the heap list
+        :param j: the second item's position of the heap list
+        :return true if items[i] < items[j], otherwise false.
+        """
+        raise NotImplementedError()
+
+    def push(self, x):
+        """Push a new item into heap"""
+        raise NotImplementedError()
+
+    def pop(self):
+        """Pop an item from the heap"""
+        raise NotImplementedError()
+
+    def swap(self, i, j):
+        """swap items between position i and j of the heap"""
+        raise NotImplementedError()
+
+
+def init(h):
+    # heapify
+    n = len(h)
+    for i in range(n/2 - 1, -1):
+        down(h, i, n)
+
+
+def push(h, x):
+    h.push(x)
+    up(h, len(h)-1)
+
+
+def pop(h):
+    n = len(h) - 1
+    h.swap(0, n)
+    down(h, 0, n)
+    return h.pop()
+
+
+def remove(h, i):
+    n = len(h) - 1
+    if n != i:
+        h.swap(i, n)
+        down(h, i, n)
+        up(h, i)
+
+    return h.pop()
+
+
+def fix(h, i):
+    down(h, i, len(h))
+    up(h, i)
+
+
+def up(h, j):
+    while j > 0:
+        i = (j - 1) / 2
+        if i == j or not h.cmp(j, i):
+            break
+
+        h.swap(i, j)
+        j = i
+
+
+def down(h, i, n):
+    while True:
+        j1 = 2*i + 1
+        if j1 >= n or j1 < 0:
+            break
+
+        j = j1
+        j2 = j1 + 1
+        if j2 < n and not h.cmp(j1, j2):
+            j = j2
+
+        if not h.cmp(j, i):
+            break
+
+        h.swap(i, j)
+        i = j

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+from .container import heap
+from .container.heap import HeapOperation
+
+
+class PeerHeap(HeapOperation):
+    def __init__(self):
+        self.peers = []
+
+    def cmp(self, i, j):
+        return self.peers[i] < self.peers[j]
+
+    def push(self, x):
+        x.index = len(self.peers)
+        self.peers.append(x)
+
+    def pop(self):
+        n = len(self.peers)
+        item = self.peers[n-1]
+        item.index = -1
+        del self.peers[n - 1]
+        return item
+
+    def __len__(self):
+        return len(self.peers)
+
+    def swap(self, i, j):
+        self.peers[i], self.peers[j] = self.peers[j], self.peers[i]
+        self.peers[i].index = i
+        self.peers[j].index = j
+
+    def update_peer(self, peer):
+        """Update the peer's position in the heap after peer's score changed"""
+        heap.fix(self, peer.index)
+
+    def pop_peer(self):
+        """Pop the top peer from the heap
+
+        :return
+            return the top peer and remove it from the heap if heap is not
+            empty.Otherwise return None.
+        """
+        if len(self.peers) == 0:
+            return None
+        return heap.pop(self)
+
+    def push_peer(self, peer):
+        """Push a new peer into the heap"""
+        heap.push(self, peer)
+
+    def peek_peer(self):
+        """Return the top peer of the heap
+        :return
+            return the top peer if heap is not empty. Otherwise return None.
+        """
+
+        if len(self.peers) == 0:
+            return None
+
+        return self.peers[0]

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -8,8 +8,11 @@ class PeerHeap(HeapOperation):
     def __init__(self):
         self.peers = []
 
-    def cmp(self, i, j):
-        return self.peers[i] < self.peers[j]
+    def size(self):
+        return len(self.peers)
+
+    def less(self, i, j):
+        return self.peers[i].score < self.peers[j].score
 
     def push(self, x):
         x.index = len(self.peers)

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from __future__ import absolute_import
 
 from .container import heap
@@ -7,7 +27,7 @@ from .container.heap import HeapOperation
 class PeerHeap(HeapOperation):
     """PeerHeap maintains a min-heap of peers based on their scores."""
 
-    __slots__ = 'peers'
+    __slots__ = ('peers',)
 
     def __init__(self):
         self.peers = []

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -5,6 +5,10 @@ from .container.heap import HeapOperation
 
 
 class PeerHeap(HeapOperation):
+    """PeerHeap maintains a min-heap of peers based on their scores."""
+
+    __slots__ = 'peers'
+
     def __init__(self):
         self.peers = []
 
@@ -19,10 +23,7 @@ class PeerHeap(HeapOperation):
         self.peers.append(x)
 
     def pop(self):
-        n = len(self.peers)
-        item = self.peers[n-1]
-        item.index = -1
-        del self.peers[n - 1]
+        item = self.peers.pop()
         return item
 
     def swap(self, i, j):
@@ -41,7 +42,7 @@ class PeerHeap(HeapOperation):
             return the top peer and remove it from the heap if heap is not
             empty.Otherwise return None.
         """
-        if len(self.peers) == 0:
+        if not self.peers:
             return None
         return heap.pop(self)
 
@@ -55,7 +56,7 @@ class PeerHeap(HeapOperation):
             return the top peer if heap is not empty. Otherwise return None.
         """
 
-        if len(self.peers) == 0:
+        if not self.peers:
             return None
 
         return self.peers[0]

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -11,7 +11,7 @@ class PeerHeap(HeapOperation):
     def size(self):
         return len(self.peers)
 
-    def less(self, i, j):
+    def lt(self, i, j):
         return self.peers[i].score < self.peers[j].score
 
     def push(self, x):

--- a/tchannel/peer_heap.py
+++ b/tchannel/peer_heap.py
@@ -25,9 +25,6 @@ class PeerHeap(HeapOperation):
         del self.peers[n - 1]
         return item
 
-    def __len__(self):
-        return len(self.peers)
-
     def swap(self, i, j):
         self.peers[i], self.peers[j] = self.peers[j], self.peers[i]
         self.peers[i].index = i

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -106,9 +106,6 @@ class Peer(object):
         # index records the position of the peer in the peer heap
         self.index = -1
 
-    def __lt__(self, other):
-        return self.score < other.score
-
     def connect(self):
         """Get a connection to this peer.
 

--- a/tests/container/test_heap.py
+++ b/tests/container/test_heap.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 import random
 import sys
+import math
 import pytest
 import six
-from tchannel.container import heap
 
+from tchannel.container import heap
 from tchannel.container.heap import HeapOperation
 
 
@@ -22,16 +23,10 @@ class IntHeap(HeapOperation):
         self.values.append(x)
 
     def pop(self):
-        n = len(self.values)
-        item = self.values[n - 1]
-        del self.values[n - 1]
-        return item
+        return self.values.pop()
 
     def swap(self, i, j):
         self.values[i], self.values[j] = self.values[j], self.values[i]
-
-
-n = 1000
 
 
 @pytest.fixture
@@ -39,61 +34,71 @@ def int_heap():
     return IntHeap()
 
 
-def create_values(n):
-    values = []
-    for i in six.moves.range(n):
-        values.append(i)
+@pytest.fixture(params=['unique', 'duplicate', 'reverse'])
+def values(request):
+    n = 1000
+    v = []
 
-    random.shuffle(values)
-    return values
+    if request.param == "unique":
+        for i in six.moves.range(n):
+            v.append(i)
+        random.shuffle(v)
+    elif request.param == "duplicate":
+        for _ in six.moves.range(n):
+            v.append(random.randint(0, math.floor(n/20)))
+    elif request.param == "reverse":
+        for i in six.moves.range(n, -1, -1):
+            v.append(i)
+
+    return v
 
 
 def verify(ph, parent):
     child1 = 2 * parent + 1
     child2 = 2 * parent + 2
     if child2 < ph.size():
-        assert ph.lt(parent, child1)
+        assert not ph.lt(child1, parent)
         verify(ph, child1)
 
     if child2 < ph.size():
-        assert ph.lt(parent, child2)
+        assert not ph.lt(child2, parent)
         verify(ph, child2)
 
 
-def test_init(int_heap):
-    int_heap.values = create_values(n)
+def test_init(int_heap, values):
+    int_heap.values = values
     heap.init(int_heap)
     verify(int_heap, 0)
 
 
-def test_push(int_heap):
-    values = create_values(n)
+def test_push(int_heap, values):
     for value in values:
         heap.push(int_heap, value)
         verify(int_heap, 0)
 
-    assert int_heap.size() == n
+    assert int_heap.size() == len(values)
 
 
-def test_pop(int_heap):
-    values = create_values(n)
+def test_pop(int_heap, values):
     for value in values:
         heap.push(int_heap, value)
         verify(int_heap, 0)
 
-    for i in six.moves.range(n):
-        assert i == heap.pop(int_heap)
+    n = len(values)
+    for _ in six.moves.range(n):
+        heap.pop(int_heap)
+        verify(int_heap, 0)
 
     assert int_heap.size() == 0
 
 
-def test_remove(int_heap):
-    values = create_values(n)
+def test_remove(int_heap, values):
     for value in values:
         heap.push(int_heap, value)
         verify(int_heap, 0)
 
     # random remove item from the heap
+    n = len(values)
     for i in six.moves.range(n - 1, -1, -1):
         heap.remove(int_heap, random.randint(0, i))
         verify(int_heap, 0)
@@ -102,7 +107,7 @@ def test_remove(int_heap):
 @pytest.mark.heapfuzz
 @pytest.mark.skipif(True, reason='stress test for the value heap operations')
 def test_heap_fuzz(int_heap):
-    for i in six.moves.range(random.randint(1, 100000)):
+    for _ in six.moves.range(random.randint(1, 100000)):
         ops = random.randint(0, 1)
         if ops == 0:  # push
             heap.push(int_heap, random.randint(0, sys.maxint))
@@ -116,9 +121,9 @@ def test_heap_fuzz(int_heap):
         verify(int_heap, 0)
 
 
-def smallest(values):
+def smallest(vs):
     m = sys.maxint
-    for value in values:
+    for value in vs:
         if value < m:
             m = value
     return m

--- a/tests/container/test_heap.py
+++ b/tests/container/test_heap.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import random
 import sys
 import pytest
+import six
 from tchannel.container import heap
 
 from tchannel.container.heap import HeapOperation
@@ -40,7 +41,7 @@ def int_heap():
 
 def create_values(n):
     values = []
-    for i in range(n):
+    for i in six.moves.range(n):
         values.append(i)
 
     random.shuffle(values)
@@ -80,16 +81,28 @@ def test_pop(int_heap):
         heap.push(int_heap, value)
         verify(int_heap, 0)
 
-    for i in range(n):
+    for i in six.moves.range(n):
         assert i == heap.pop(int_heap)
 
     assert int_heap.size() == 0
 
 
+def test_remove(int_heap):
+    values = create_values(n)
+    for value in values:
+        heap.push(int_heap, value)
+        verify(int_heap, 0)
+
+    # random remove item from the heap
+    for i in six.moves.range(n - 1, -1, -1):
+        heap.remove(int_heap, random.randint(0, i))
+        verify(int_heap, 0)
+
+
 @pytest.mark.heapfuzz
 @pytest.mark.skipif(True, reason='stress test for the value heap operations')
 def test_heap_fuzz(int_heap):
-    for i in range(random.randint(1, 100000)):
+    for i in six.moves.range(random.randint(1, 100000)):
         ops = random.randint(0, 1)
         if ops == 0:  # push
             heap.push(int_heap, random.randint(0, sys.maxint))

--- a/tests/container/test_heap.py
+++ b/tests/container/test_heap.py
@@ -14,7 +14,7 @@ class IntHeap(HeapOperation):
     def size(self):
         return len(self.values)
 
-    def less(self, i, j):
+    def lt(self, i, j):
         return self.values[i] < self.values[j]
 
     def push(self, x):
@@ -51,11 +51,11 @@ def verify(ph, parent):
     child1 = 2 * parent + 1
     child2 = 2 * parent + 2
     if child2 < ph.size():
-        assert ph.less(parent, child1)
+        assert ph.lt(parent, child1)
         verify(ph, child1)
 
     if child2 < ph.size():
-        assert ph.less(parent, child2)
+        assert ph.lt(parent, child2)
         verify(ph, child2)
 
 

--- a/tests/container/test_heap.py
+++ b/tests/container/test_heap.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from __future__ import absolute_import
 import random
 import sys
@@ -84,9 +104,8 @@ def test_pop(int_heap, values):
         heap.push(int_heap, value)
         verify(int_heap, 0)
 
-    n = len(values)
-    for _ in six.moves.range(n):
-        heap.pop(int_heap)
+    for i in sorted(values):
+        assert i == heap.pop(int_heap)
         verify(int_heap, 0)
 
     assert int_heap.size() == 0

--- a/tests/container/test_heap.py
+++ b/tests/container/test_heap.py
@@ -1,0 +1,111 @@
+from __future__ import absolute_import
+import random
+import sys
+import pytest
+from tchannel.container import heap
+
+from tchannel.container.heap import HeapOperation
+
+
+class IntHeap(HeapOperation):
+    def __init__(self):
+        self.values = []
+
+    def size(self):
+        return len(self.values)
+
+    def less(self, i, j):
+        return self.values[i] < self.values[j]
+
+    def push(self, x):
+        self.values.append(x)
+
+    def pop(self):
+        n = len(self.values)
+        item = self.values[n - 1]
+        del self.values[n - 1]
+        return item
+
+    def swap(self, i, j):
+        self.values[i], self.values[j] = self.values[j], self.values[i]
+
+
+n = 1000
+
+
+@pytest.fixture
+def int_heap():
+    return IntHeap()
+
+
+def create_values(n):
+    values = []
+    for i in range(n):
+        values.append(i)
+
+    random.shuffle(values)
+    return values
+
+
+def verify(ph, parent):
+    child1 = 2 * parent + 1
+    child2 = 2 * parent + 2
+    if child2 < ph.size():
+        assert ph.less(parent, child1)
+        verify(ph, child1)
+
+    if child2 < ph.size():
+        assert ph.less(parent, child2)
+        verify(ph, child2)
+
+
+def test_init(int_heap):
+    int_heap.values = create_values(n)
+    heap.init(int_heap)
+    verify(int_heap, 0)
+
+
+def test_push(int_heap):
+    values = create_values(n)
+    for value in values:
+        heap.push(int_heap, value)
+        verify(int_heap, 0)
+
+    assert int_heap.size() == n
+
+
+def test_pop(int_heap):
+    values = create_values(n)
+    for value in values:
+        heap.push(int_heap, value)
+        verify(int_heap, 0)
+
+    for i in range(n):
+        assert i == heap.pop(int_heap)
+
+    assert int_heap.size() == 0
+
+
+@pytest.mark.heapfuzz
+@pytest.mark.skipif(True, reason='stress test for the value heap operations')
+def test_heap_fuzz(int_heap):
+    for i in range(random.randint(1, 100000)):
+        ops = random.randint(0, 1)
+        if ops == 0:  # push
+            heap.push(int_heap, random.randint(0, sys.maxint))
+        elif ops == 1:  # pop
+            if int_heap.size():
+                heap.pop(int_heap)
+
+        if int_heap.size():
+            assert smallest(int_heap.values) == int_heap.values[0]
+
+        verify(int_heap, 0)
+
+
+def smallest(values):
+    m = sys.maxint
+    for value in values:
+        if value < m:
+            m = value
+    return m

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -1,18 +1,36 @@
 from __future__ import absolute_import
 import sys
+import math
 
 import mock
 import random
 import pytest
+import six
 from tchannel.peer_heap import PeerHeap
-
-
-n = 1000
 
 
 @pytest.fixture
 def peer_heap():
     return PeerHeap()
+
+
+@pytest.fixture(params=['unique', 'duplicate', 'reverse'])
+def peers(request):
+    n = 1000
+    v = []
+
+    if request.param == "unique":
+        for i in six.moves.range(n):
+            v.append(mock_peer(i))
+        random.shuffle(v)
+    elif request.param == "duplicate":
+        for _ in six.moves.range(n):
+            v.append(mock_peer(random.randint(0, math.floor(n/20))))
+    elif request.param == "reverse":
+        for i in six.moves.range(n, -1, -1):
+            v.append(mock_peer(i))
+
+    return v
 
 
 def mock_peer(score=None):
@@ -22,59 +40,49 @@ def mock_peer(score=None):
     return peer
 
 
-def mock_peers(n):
-    peers = []
-    for i in range(n):
-        peers.append(mock_peer(i))
-
-    random.shuffle(peers)
-    return peers
-
-
 def verify(ph, parent):
+    """Assert the peer is still well-maintained."""
     child1 = 2*parent + 1
     child2 = 2*parent + 2
     if child2 < ph.size():
-        assert ph.lt(parent, child1)
+        assert not ph.lt(child1, parent)
         verify(ph, child1)
 
     if child2 < ph.size():
-        assert ph.lt(parent, child2)
+        assert not ph.lt(child2, parent)
         verify(ph, child2)
 
 
-def test_push(peer_heap):
-    peers = mock_peers(n)
+def test_push(peer_heap, peers):
     for peer in peers:
         peer_heap.push_peer(peer)
         verify(peer_heap, 0)
 
-    assert peer_heap.size() == n
+    assert peer_heap.size() == len(peers)
 
 
-def test_pop(peer_heap):
-    peers = mock_peers(n)
+def test_pop(peer_heap, peers):
     for peer in peers:
         peer_heap.push_peer(peer)
         verify(peer_heap, 0)
 
-    for i in range(n):
-        assert i == peer_heap.pop_peer().score
+    n = len(peers)
+    for _ in six.moves.range(n):
+        peer_heap.pop_peer()
+        verify(peer_heap, 0)
 
     assert peer_heap.size() == 0
 
 
-def test_update(peer_heap):
-    peers = mock_peers(n)
+def test_update(peer_heap, peers):
     for peer in peers:
         peer_heap.push_peer(peer)
         verify(peer_heap, 0)
 
-    p = peer_heap.peers[n-1]
+    p = peer_heap.peers[len(peers) - 1]
     p.score = -1
     peer_heap.update_peer(p)
     verify(peer_heap, 0)
-
     assert peer_heap.peek_peer().score == -1
     assert peer_heap.peek_peer() == p
 
@@ -82,7 +90,7 @@ def test_update(peer_heap):
 @pytest.mark.heapfuzz
 @pytest.mark.skipif(True, reason='stress test for the peer heap operations')
 def test_heap_fuzz(peer_heap):
-    for i in range(random.randint(1, 1000000)):
+    for _ in six.moves.range(random.randint(1, 100000)):
         ops = random.randint(0, 2)
         if ops == 0:    # push
             peer_heap.push_peer(mock_peer())
@@ -101,9 +109,9 @@ def test_heap_fuzz(peer_heap):
         verify(peer_heap, 0)
 
 
-def smallest(peers):
+def smallest(ps):
     m = sys.maxint
-    for peer in peers:
+    for peer in ps:
         if peer.score < m:
             m = peer.score
 

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+import sys
+
+import mock
+import random
+import pytest
+from tchannel.peer_heap import PeerHeap
+
+
+n = 1000
+
+
+@pytest.fixture
+def peer_heap():
+    return PeerHeap()
+
+
+def lt(s, o):
+    return s.score < o.score
+
+
+def mock_peer(score=None):
+    peer = mock.MagicMock()
+    peer.index = -1
+    peer.score = score if score is not None else random.randint(0, sys.maxint)
+    peer.__lt__ = lt
+    return peer
+
+
+def mock_peers(n):
+    peers = []
+    for i in range(n):
+        peers.append(mock_peer(i))
+
+    random.shuffle(peers)
+    return peers
+
+
+def test_push(peer_heap):
+    peers = mock_peers(n)
+    for peer in peers:
+        peer_heap.push_peer(peer)
+
+    assert len(peer_heap) == n
+
+
+def test_pop(peer_heap):
+    peers = mock_peers(n)
+    for peer in peers:
+        peer_heap.push_peer(peer)
+
+    for i in range(n):
+        assert i == peer_heap.pop_peer().score
+
+    assert len(peer_heap) == 0
+
+
+def test_update(peer_heap):
+    peers = mock_peers(n)
+    for peer in peers:
+        peer_heap.push_peer(peer)
+
+    p = peer_heap.peers[n-1]
+    p.score = -1
+    peer_heap.update_peer(p)
+
+    assert peer_heap.peek_peer().score == -1
+    assert peer_heap.peek_peer() == p
+
+
+@pytest.mark.heapfuzz
+@pytest.mark.skipif(True, reason='stress test for the peer heap operations')
+def test_heap_fuzz(peer_heap):
+    for i in range(random.randint(1, 1000000)):
+        ops = random.randint(0, 2)
+        if ops == 0:    # push
+            peer_heap.push_peer(mock_peer())
+        elif ops == 1:  # pop
+            peer_heap.pop_peer()
+        elif ops == 2:  # update
+            if len(peer_heap) <= 0:
+                continue
+            p = peer_heap.peers[random.randint(0, len(peer_heap) - 1)]
+            p.score = random.randint(0, sys.maxint)
+            peer_heap.update_peer(p)
+
+        if len(peer_heap.peers):
+            assert smallest(peer_heap.peers) == peer_heap.peek_peer().score
+
+
+def smallest(peers):
+    m = sys.maxint
+    for peer in peers:
+        if peer.score < m:
+            m = peer.score
+
+    return m

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -1,3 +1,23 @@
+# Copyright (c) 2015 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 from __future__ import absolute_import
 import sys
 import math

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -35,11 +35,11 @@ def verify(ph, parent):
     child1 = 2*parent + 1
     child2 = 2*parent + 2
     if child2 < ph.size():
-        assert not ph.less(child1, parent)
+        assert ph.less(parent, child1)
         verify(ph, child1)
 
     if child2 < ph.size():
-        assert not ph.less(child2, parent)
+        assert ph.less(parent, child2)
         verify(ph, child2)
 
 
@@ -49,7 +49,7 @@ def test_push(peer_heap):
         peer_heap.push_peer(peer)
         verify(peer_heap, 0)
 
-    assert len(peer_heap) == n
+    assert peer_heap.size() == n
 
 
 def test_pop(peer_heap):
@@ -61,7 +61,7 @@ def test_pop(peer_heap):
     for i in range(n):
         assert i == peer_heap.pop_peer().score
 
-    assert len(peer_heap) == 0
+    assert peer_heap.size() == 0
 
 
 def test_update(peer_heap):
@@ -95,7 +95,7 @@ def test_heap_fuzz(peer_heap):
             p.score = random.randint(0, sys.maxint)
             peer_heap.update_peer(p)
 
-        if len(peer_heap.peers):
+        if peer_heap.size():
             assert smallest(peer_heap.peers) == peer_heap.peek_peer().score
 
         verify(peer_heap, 0)

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -35,11 +35,11 @@ def verify(ph, parent):
     child1 = 2*parent + 1
     child2 = 2*parent + 2
     if child2 < ph.size():
-        assert ph.less(parent, child1)
+        assert ph.lt(parent, child1)
         verify(ph, child1)
 
     if child2 < ph.size():
-        assert ph.less(parent, child2)
+        assert ph.lt(parent, child2)
         verify(ph, child2)
 
 

--- a/tests/test_peer_heap.py
+++ b/tests/test_peer_heap.py
@@ -15,15 +15,10 @@ def peer_heap():
     return PeerHeap()
 
 
-def lt(s, o):
-    return s.score < o.score
-
-
 def mock_peer(score=None):
     peer = mock.MagicMock()
     peer.index = -1
     peer.score = score if score is not None else random.randint(0, sys.maxint)
-    peer.__lt__ = lt
     return peer
 
 
@@ -36,10 +31,23 @@ def mock_peers(n):
     return peers
 
 
+def verify(ph, parent):
+    child1 = 2*parent + 1
+    child2 = 2*parent + 2
+    if child2 < ph.size():
+        assert not ph.less(child1, parent)
+        verify(ph, child1)
+
+    if child2 < ph.size():
+        assert not ph.less(child2, parent)
+        verify(ph, child2)
+
+
 def test_push(peer_heap):
     peers = mock_peers(n)
     for peer in peers:
         peer_heap.push_peer(peer)
+        verify(peer_heap, 0)
 
     assert len(peer_heap) == n
 
@@ -48,6 +56,7 @@ def test_pop(peer_heap):
     peers = mock_peers(n)
     for peer in peers:
         peer_heap.push_peer(peer)
+        verify(peer_heap, 0)
 
     for i in range(n):
         assert i == peer_heap.pop_peer().score
@@ -59,10 +68,12 @@ def test_update(peer_heap):
     peers = mock_peers(n)
     for peer in peers:
         peer_heap.push_peer(peer)
+        verify(peer_heap, 0)
 
     p = peer_heap.peers[n-1]
     p.score = -1
     peer_heap.update_peer(p)
+    verify(peer_heap, 0)
 
     assert peer_heap.peek_peer().score == -1
     assert peer_heap.peek_peer() == p
@@ -86,6 +97,8 @@ def test_heap_fuzz(peer_heap):
 
         if len(peer_heap.peers):
             assert smallest(peer_heap.peers) == peer_heap.peek_peer().score
+
+        verify(peer_heap, 0)
 
 
 def smallest(peers):


### PR DESCRIPTION
The existing python heapq lib doesn't provide the api to update items in the middle of the heap. That's why I implement our own heap. The implementation of the heap refers to the go [heap](https://github.com/golang/go/blob/master/src/container/heap/heap.go).
It provides the basic operations:
* update
* push
* pop
* peek

@blampe @abhinav 

Resolves #51.