### PR TITLE
Add support for registering fallback endpoints.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ Changes by Version
 - ``tchannel.TChannel.FALLBACK`` may now be used to register fallback endpoints
   which are called for requests with unrecognized endpoints. For more
   information, see :ref:`fallback-endpoint`
-- Expose ``timeout``, ``service``, and ``trace`` attributes on ``Request``
-  objects inside endpoint handlers.
+- Expose ``timeout`` and ``service`` attributes on ``Request`` objects inside
+  endpoint handlers.
 
 
 0.20.2 (2015-11-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changes by Version
 -------------------
 
 - Add support for ``rd`` transport header.
+- ``tchannel.TChannel.FALLBACK`` may now be used to register fallback endpoints
+  which are called for requests with unrecognized endpoints. For more
+  information, see :ref:`fallback-endpoint`
+- Expose ``timeout``, ``service``, and ``trace`` attributes on ``Request``
+  objects inside endpoint handlers.
 
 
 0.20.2 (2015-11-25)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,8 +8,8 @@ Can I register an endpoint that accepts all requests?
 
 The fallback endpoint is the endpoint called when an unrecognized request is
 received. By default, the fallback endpoint simply returns a
-``BadRequestError`` to the caller. This behavior may be overriden by
-registering a raw endpoint with ``TChannel.FALLBACK``.
+``BadRequestError`` to the caller. This behavior may be changed by
+registering an endpoint with ``TChannel.FALLBACK``.
 
 .. code-block:: python
 
@@ -17,7 +17,7 @@ registering a raw endpoint with ``TChannel.FALLBACK``.
 
     server = TChannel(name='myservice')
 
-    @server.register('raw', TChannel.FALLBACK)
+    @server.register(TChannel.FALLBACK)
     def handler(request):
         # ...
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,0 +1,27 @@
+FAQ
+===
+
+.. _fallback-endpoint:
+
+Can I register an endpoint that accepts all requests?
+-----------------------------------------------------
+
+The fallback endpoint is the endpoint called when an unrecognized request is
+received. By default, the fallback endpoint simply returns a
+``BadRequestError`` to the caller. This behavior may be overriden by
+registering a raw endpoint with ``TChannel.FALLBACK``.
+
+.. code-block:: python
+
+    from tchannel import TChannel
+
+    server = TChannel(name='myservice')
+
+    @server.register('raw', TChannel.FALLBACK)
+    def handler(request):
+        # ...
+
+This may be used to implement a TChannel server that can handle requests to all
+endpoints. Note that for the fallback endpoint, you have access to the raw
+bytes of the headers and the body. These must be serialized/deserialized
+manually.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,4 +26,5 @@ A Python implementation of `TChannel`_.
 
    guide
    api
+   faq
    changelog

--- a/tchannel/request.py
+++ b/tchannel/request.py
@@ -47,6 +47,16 @@ class Request(object):
         The most useful piece of information here is probably
         ``request.transport.caller_name``, which is the identity of the
         application that created this request.
+
+    :ivar service:
+        Name of the service being called.
+
+    :ivar timeout:
+        Amount of time (in seconds) within which this request is expected to
+        finish.
+
+    :ivar trace:
+        Zipkin tracing information for this request.
     """
 
     # TODO move over other props from tchannel.tornado.request
@@ -54,8 +64,11 @@ class Request(object):
     __slots__ = (
         'body',
         'headers',
+        'service',
         'transport',
         'endpoint',
+        'timeout',
+        'trace',
     )
 
     def __init__(
@@ -64,11 +77,17 @@ class Request(object):
         headers=None,
         transport=None,
         endpoint=None,
+        service=None,
+        timeout=None,
+        trace=None,
     ):
         self.body = body
         self.headers = headers
         self.transport = transport
         self.endpoint = endpoint
+        self.service = service
+        self.timeout = timeout
+        self.trace = trace
 
 
 class TransportHeaders(object):

--- a/tchannel/request.py
+++ b/tchannel/request.py
@@ -49,7 +49,10 @@ class Request(object):
         application that created this request.
 
     :ivar service:
-        Name of the service being called.
+        Name of the service being called. Inside request handlers, this is
+        usually the name of "this" service itself. However, for services that
+        simply forward requests to other services, this is the name of the
+        target service.
 
     :ivar timeout:
         Amount of time (in seconds) within which this request is expected to

--- a/tchannel/request.py
+++ b/tchannel/request.py
@@ -54,9 +54,6 @@ class Request(object):
     :ivar timeout:
         Amount of time (in seconds) within which this request is expected to
         finish.
-
-    :ivar trace:
-        Zipkin tracing information for this request.
     """
 
     # TODO move over other props from tchannel.tornado.request
@@ -68,7 +65,6 @@ class Request(object):
         'transport',
         'endpoint',
         'timeout',
-        'trace',
     )
 
     def __init__(
@@ -79,7 +75,6 @@ class Request(object):
         endpoint=None,
         service=None,
         timeout=None,
-        trace=None,
     ):
         self.body = body
         self.headers = headers
@@ -87,7 +82,6 @@ class Request(object):
         self.endpoint = endpoint
         self.service = service
         self.timeout = timeout
-        self.trace = trace
 
 
 class TransportHeaders(object):

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -237,6 +237,10 @@ class TChannel(object):
         return self._dep_tchannel.hostport
 
     def register(self, scheme, endpoint=None, handler=None, **kwargs):
+        if scheme is self.FALLBACK:
+            # scheme is not required for fallback endpoints
+            endpoint = scheme
+            scheme = None
 
         def decorator(fn):
 

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -79,6 +79,8 @@ class TChannel(object):
 
     """
 
+    FALLBACK = DeprecatedTChannel.FALLBACK
+
     def __init__(self, name, hostport=None, process_name=None,
                  known_peers=None, trace=False):
         """

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -176,7 +176,6 @@ class RequestDispatcher(object):
         try:
             # New impl - the handler takes a request and returns a response
             if self._handler_returns_response:
-
                 # convert deprecated req to new top-level req
                 b = yield request.get_body()
                 he = yield request.get_header()
@@ -188,6 +187,9 @@ class RequestDispatcher(object):
                     headers=he,
                     transport=t,
                     endpoint=request.endpoint,
+                    service=request.service,
+                    timeout=request.ttl,
+                    trace=request.tracing,
                 )
 
                 # Not safe to have coroutine yields statement within

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -189,7 +189,6 @@ class RequestDispatcher(object):
                     endpoint=request.endpoint,
                     service=request.service,
                     timeout=request.ttl,
-                    trace=request.tracing,
                 )
 
                 # Not safe to have coroutine yields statement within

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -436,7 +436,7 @@ def test_forwarding(tmpdir):
         name='proxy-client', known_peers=[real_server.hostport],
     )
 
-    @proxy_server.register('raw', TChannel.FALLBACK)
+    @proxy_server.register(TChannel.FALLBACK)
     @gen.coroutine
     def handler(request):
         response = yield proxy_server_client.call(

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -449,7 +449,6 @@ def test_forwarding(tmpdir):
             retry_on=request.transport.retry_flags,
             retry_limit=0,
             shard_key=request.transport.shard_key,
-            trace=request.trace,
         )
         raise gen.Return(response)
 

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -449,6 +449,7 @@ def test_forwarding(tmpdir):
             retry_on=request.transport.retry_flags,
             retry_limit=0,
             shard_key=request.transport.shard_key,
+            routing_delegate=request.transport.routing_delegate,
         )
         raise gen.Return(response)
 


### PR DESCRIPTION
Expose request, timeout, and trace in the Request object inside handlers.