### PR TITLE
Change tchannel.thrift.register to return the unchanged handler.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Changes by Version
   endpoint handlers.
 - Add support for zipkin trace sampling.
 - Disable the retry for all zipkin trace submit.
+- **BREAKING** - Support unit testing endpoints by calling the handler
+  functions directly. This is enabled by changing ``tchannel.thrift.register``
+  to return the registered function unmodified. See Upgrade Guide for more
+  details.
 
 
 0.20.2 (2015-11-25)

--- a/tchannel/thrift/rw.py
+++ b/tchannel/thrift/rw.py
@@ -308,10 +308,9 @@ def register(dispatcher, service, handler=None, method=None):
         )
         assert not function.oneway
 
-        handler = build_handler(function, handler)
         dispatcher.register(
             function.endpoint,
-            handler,
+            build_handler(function, handler),
             ThriftRWSerializer(service._module, function._request_cls),
             ThriftRWSerializer(service._module, function._response_cls),
         )

--- a/tchannel/thrift/server.py
+++ b/tchannel/thrift/server.py
@@ -87,13 +87,13 @@ def register(dispatcher, service_module, handler, method=None, service=None):
     # if the dispatcher is set to deal with handlers that
     # return responses, then use new api, else use deprecated
     if dispatcher._handler_returns_response:
-        handler = build_handler(result_type, handler)
+        new_handler = build_handler(result_type, handler)
     else:
-        handler = deprecated_build_handler(result_type, handler)
+        new_handler = deprecated_build_handler(result_type, handler)
 
     dispatcher.register(
         endpoint,
-        handler,
+        new_handler,
         ThriftSerializer(args_type),
         ThriftSerializer(result_type)
     )

--- a/tests/schemes/test_thrift.py
+++ b/tests/schemes/test_thrift.py
@@ -23,6 +23,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 import pytest
 from tornado import gen
 from tornado import concurrent
@@ -1162,3 +1163,80 @@ def test_exception_status_code_is_set(server, ThriftTest, server_ttypes):
     )
 
     assert 1 == res.status_code
+
+
+##############################################################################
+# Calling registered functions directly should be equivalent to calling them
+# as if they weren't registered at all
+
+
+def body(**kwargs):
+    """Constructs fake Request objects.
+
+    The ``_headers`` kwarg may be used to set the header on the Request
+    object.
+    """
+    request = mock.Mock()
+    for k, v in kwargs.items():
+        setattr(request, k, v)
+    return request
+
+
+def test_void_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testVoid(request):
+        pass
+
+    resp = testVoid(Request())
+    assert resp is None
+
+
+def test_void_with_headers_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testVoid(request):
+        assert request.headers == {'req': 'header'}
+        return Response(headers={'resp': 'header'})
+
+    resp = testVoid(Request(headers={'req': 'header'}))
+    assert resp.headers == {'resp': 'header'}
+    assert resp.body is None
+
+
+def test_non_void_call_directly(server, ThriftTest):
+
+    @server.thrift.register(ThriftTest)
+    def testString(request):
+        return request.body.thing
+
+    resp = testString(Request(body=body(thing='howdy')))
+    assert resp == 'howdy'
+
+
+def test_non_void_with_headers_call_directly(
+    server, service, ThriftTest, server_ttypes, client_ttypes
+):
+
+    # Given this test server:
+
+    @server.thrift.register(ThriftTest)
+    def testStruct(request):
+        assert request.headers == {'req': 'header'}
+        assert request.body.thing.string_thing == 'req string'
+
+        return Response(
+            server_ttypes.Xtruct(string_thing="resp string"),
+            headers={'resp': 'header'},
+        )
+
+    resp = testStruct(
+        Request(
+            headers={'req': 'header'},
+            body=body(thing=client_ttypes.Xtruct("req string")),
+        )
+    )
+
+    assert isinstance(resp, Response)
+    assert resp.headers == {'resp': 'header'}
+    assert resp.body == server_ttypes.Xtruct("resp string")


### PR DESCRIPTION
This is a backport of #302 to 0.21.