### PR TITLE
Fix the bug to generator signed trace_id

### DIFF
--- a/tchannel/rw.py
+++ b/tchannel/rw.py
@@ -347,7 +347,7 @@ class NumberReadWriter(ReadWriter):
         1: '>B',
         2: '>H',
         4: '>I',
-        8: '>q',
+        8: '>Q',
     }
 
     __slots__ = ('_width', '_format')

--- a/tchannel/zipkin/formatters.py
+++ b/tchannel/zipkin/formatters.py
@@ -124,7 +124,7 @@ def binary_annotation_formatter(annotation):
 
 
 def i64_to_string(data):
-    return struct.pack('>q', data)
+    return struct.pack('>Q', data)
 
 
 def i64_to_base64(data):

--- a/tchannel/zipkin/trace.py
+++ b/tchannel/zipkin/trace.py
@@ -40,12 +40,9 @@ import random
 def _uniq_id():
     """Create a random 64-bit signed integer.
 
-    :rtype: int
+    :rtype: unsigned long
     """
-    if random.getrandbits(1):
-        return random.getrandbits(63)
-
-    return -random.getrandbits(63)
+    return random.getrandbits(64)
 
 
 class Trace(object):

--- a/tchannel/zipkin/trace.py
+++ b/tchannel/zipkin/trace.py
@@ -42,7 +42,10 @@ def _uniq_id():
 
     :rtype: int
     """
-    return random.getrandbits(63)
+    if random.getrandbits(1):
+        return random.getrandbits(63)
+
+    return -random.getrandbits(63)
 
 
 class Trace(object):

--- a/tchannel/zipkin/zipkin_trace.py
+++ b/tchannel/zipkin/zipkin_trace.py
@@ -59,7 +59,7 @@ class ZipkinTraceHook(EventHook):
 
         assert 0 <= sample_rate <= 1
         self.rate = sample_rate
-        self._check_point = self.rate * (1 << 63)
+        self._check_point = self.rate * (1 << 64)
 
     def _lucky(self, id):
         return id < self._check_point


### PR DESCRIPTION
@blampe @abhinav @breerly 
In the rw.py, we always used 'q' for struct.pack or unpack. It treats all numbers as signed long long. I double checked the our protocol, all the 64bits data are not signed. So change it to 'Q'