### PR TITLE
Remove the exception in the register method in sync tchannel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.21.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Attempting to register endpoints against a synchronous TChannel is now a no-op instead of a crash.
 
 
 0.21.2 (2016-01-05)


### PR DESCRIPTION
@blampe @abhinav 
consider a more user friendly behavior , replace the exception in sync tchannel register to log message.