### PR TITLE
connection.Writer.write() should re-raise exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changes by Version
 0.21.9 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed a bug that caused silent failures when a write attempt was made to a
+  closed connection.
 
 
 0.21.8 (2016-03-10)

--- a/tchannel/event.py
+++ b/tchannel/event.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+import sys
 import collections
 import functools
 import logging
@@ -144,8 +145,8 @@ class EventEmitter(object):
         for hook in self.hooks[event]:
             try:
                 hook(*args, **kwargs)
-            except Exception as e:
-                log.error(e.message)
+            except Exception:
+                log.error("error calling hook", exc_info=sys.exc_info())
 
 
 class EventRegistrar(object):

--- a/tchannel/rw.py
+++ b/tchannel/rw.py
@@ -496,9 +496,7 @@ class NamedChainReadWriter(ReadWriter):
                 if name != skip:
                     result[name] = value
             except ReadError as e:
-                raise ReadError(
-                    "Failed to read %s: %s" % (name, e.message)
-                )
+                raise ReadError("Failed to read %s: %s" % (name, e))
         return result
 
     def write(self, obj, stream):
@@ -538,9 +536,7 @@ class InstanceReadWriter(ReadWriter):
                 if attr != skip:
                     kwargs[attr] = value
         except ReadError as e:
-            raise ReadError(
-                "Failed to read %s: %s" % (self._cls, e.message)
-            )
+            raise ReadError("Failed to read %s: %s" % (self._cls, e))
 
         return self._cls(**kwargs)
 

--- a/tchannel/testing/vcr/patch.py
+++ b/tchannel/testing/vcr/patch.py
@@ -111,8 +111,7 @@ class PatchedClientOperation(object):
             raise TChannelError.from_code(
                 e.code,
                 description=(
-                    "The remote service threw a protocol error: %s" %
-                    e.message
+                    "The remote service threw a protocol error: %s" % (e,)
                 )
             )
 

--- a/tchannel/testing/vcr/server.py
+++ b/tchannel/testing/vcr/server.py
@@ -53,7 +53,7 @@ def wrap_uncaught(func=None, reraise=None):
                     # TODO maybe use traceback.format_exc to also send a
                     # traceback?
                     raise e
-                raise proxy.VCRServiceError(e.message)
+                raise proxy.VCRServiceError(str(e))
             else:
                 raise gen.Return(result)
 
@@ -150,7 +150,7 @@ class VCRProxyService(object):
         except TChannelError as e:
             raise proxy.RemoteServiceError(
                 code=e.code,
-                message=e.message,
+                message=str(e),
             )
         response_headers = yield response.get_header()
         response_body = yield response.get_body()

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -532,9 +532,10 @@ class StreamConnection(TornadoConnection):
             yield self.write(message)
             context.state = StreamState.completed
         # Stop streamming immediately if exception occurs on the handler side
-        except TChannelError as e:
+        except TChannelError:
             # raise by tchannel intentionally
-            log.info("Stop Outgoing Streams because of error: %s", e.message)
+            log.info("Stopped outgoing streams because of an error",
+                     exc_info=sys.exc_info())
 
     @tornado.gen.coroutine
     def post_response(self, response):

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -695,7 +695,7 @@ class Writer(object):
 
         def on_write(f, done):
             if f.exception():
-                log.error(f.exception())
+                log.error("write failed", exc_info=f.exc_info())
                 done.set_exc_info(f.exc_info())
             else:
                 done.set_result(f.result())
@@ -705,7 +705,7 @@ class Writer(object):
         def on_message(f):
             if f.exception():
                 io_loop.spawn_callback(next_write)
-                log.error(f.exception())
+                log.error("queue get failed", exc_info=f.exc_info())
                 return
             message, done = f.result()
             io_loop.add_future(

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -225,7 +225,7 @@ class RequestDispatcher(object):
             connection.send_error(e)
         except Exception as e:
             error = UnexpectedError(
-                description="Unexpected Error: '%s'" % e.message,
+                description="Unexpected Error: '%s'" % e,
                 id=request.id,
                 tracing=request.tracing,
             )

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -121,7 +121,7 @@ def test_invalid_message_during_streaming(mock_server):
         yield resp.get_header()
         yield resp.get_body()
 
-    assert e.value.message == u"Checksum does not match!"
+    assert 'Checksum does not match' in str(e)
 
 
 @pytest.mark.gen_test
@@ -143,5 +143,4 @@ def test_continue_message_error(mock_server):
     with pytest.raises(FatalProtocolError) as e:
         yield connection.send(callreqcontinue)
 
-    assert (e.value.message ==
-            u"missing call message after receiving continue message")
+    assert 'missing call message after receiving continue message' in str(e)

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -325,6 +325,7 @@ def test_event_hook_register():
 
 @pytest.mark.gen_test
 def test_advertise_should_take_a_router_file():
+    from tchannel.tornado.response import Response as TornadoResponse
 
     host_path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -343,7 +344,7 @@ def test_advertise_should_take_a_router_file():
     ) as mock_advertise:
         f = gen.Future()
         mock_advertise.return_value = f
-        f.set_result(Response())
+        f.set_result(TornadoResponse())
         tchannel.advertise(router_file=host_path)
 
         mock_advertise.assert_called_once_with(ANY, routers=routers,


### PR DESCRIPTION
Other changes:

- Fix deprecation warning from Hypothesis during tests
- A test was using the wrong Response class for its mocks
- Removed deprecation warnings because of usage of `BaseException.message`
- Include stack traces while logging in more places

@blampe @breerly @junchaowu 
