### PR TITLE
Fix unconsumed StreamClosedError logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changes by Version
 
 - Fixed a bug that caused silent failures when a write attempt was made to a
   closed connection.
+- Reduce ``StreamClosedError`` log noisiness for certain scenarios.
 
 
 0.21.8 (2016-03-10)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -663,7 +663,7 @@ class Reader(object):
                 lambda f: io_loop.spawn_callback(self.fill),
             )
 
-        io_loop.add_future(read_message(self.io_stream), keep_reading)
+        read_message(self.io_stream).add_done_callback(keep_reading)
 
     def get(self):
         """Receive the next message off the wire.

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -555,13 +555,12 @@ class StreamConnection(TornadoConnection):
         """send the given request and response is not required"""
         request.close_argstreams()
 
+        def on_done(future):
+            future.exception()  # < to avoid "unconsumed exception" logs
+            request.close_argstreams(force=True)
+
         stream_future = self._stream(request, self.request_message_factory)
-
-        IOLoop.current().add_future(
-            stream_future,
-            lambda f: request.close_argstreams(force=True)
-        )
-
+        stream_future.add_done_callback(on_done)
         return stream_future
 
     def send_request(self, request):


### PR DESCRIPTION
This fixes two places which were causing unconsumed Future exceptions:

1.  `stream_request`'s future simply wasn't consumed
2. During tests, the IOLoop was being stopped before the callback given to `read_message(...).add_future(...)` could be called. I think this same issue would affect people using `IOLoop.run_sync`. The fix is simply to use `add_done_callback` in this case.
