### PR TITLE
PeerHeap: Make things cheaper

### DIFF
--- a/tchannel/peer_strategy.py
+++ b/tchannel/peer_strategy.py
@@ -54,7 +54,7 @@ class PreferIncomingCalculator(RankCalculator):
         if peer.is_ephemeral or not peer.connections:
             return self.TIERS[0]
 
-        if not peer.incoming_connections:
+        if not peer.has_incoming_connections:
             return self.TIERS[1] + peer.total_outbound_pendings
 
         return self.TIERS[2] + peer.total_outbound_pendings

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -68,8 +68,8 @@ class Peer(object):
         'order',
         'chosen_count',
         'on_conn_change',
+        'connections',
 
-        '_connections',
         '_connecting',
         '_on_conn_change_cb',
     )
@@ -88,7 +88,8 @@ class Peer(object):
             Host-port this Peer is for.
         :param rank:
             The rank of a peer will affect the chance that the peer gets
-            selected when the client sends outbound requests.
+            selected when the client sends outbound requests. Lower rank is
+            better.
         :param on_conn_change:
             A callback method takes Peer object as input and is called whenever
             there are connection changes in the peer.
@@ -102,7 +103,7 @@ class Peer(object):
         #: Collection of all connections for this Peer. Incoming connections
         #: are added to the left side of the deque and outgoing connections to
         #: the right side.
-        self._connections = deque()
+        self.connections = deque()
 
         # This contains a future to the TornadoConnection if we're already in
         # the process of making an outgoing connection to the peer. This
@@ -139,10 +140,10 @@ class Peer(object):
             A future containing a connection to this host.
         """
         # Prefer incoming connections over outgoing connections.
-        if self._connections:
+        if self.connections:
             # First value is an incoming connection
             future = gen.Future()
-            future.set_result(self._connections[0])
+            future.set_result(self.connections[0])
             return future
 
         if self._connecting:
@@ -172,16 +173,20 @@ class Peer(object):
     def _set_on_close_cb(self, conn):
 
         def on_close():
-            self._connections.remove(conn)
+            self.connections.remove(conn)
             self._on_conn_change()
 
         conn.set_close_callback(on_close)
+
+    @property
+    def has_incoming_connections(self):
+        return self.connections and self.connections[0].direction == INCOMING
 
     def register_outgoing_conn(self, conn):
         """Add outgoing connection into the heap."""
         assert conn, "conn is required"
         conn.set_outbound_pending_change_callback(self._on_conn_change)
-        self._connections.append(conn)
+        self.connections.append(conn)
         self._set_on_close_cb(conn)
         self._on_conn_change()
 
@@ -189,7 +194,7 @@ class Peer(object):
         """Add incoming connection into the heap."""
         assert conn, "conn is required"
         conn.set_outbound_pending_change_callback(self._on_conn_change)
-        self._connections.appendleft(conn)
+        self.connections.appendleft(conn)
         self._set_on_close_cb(conn)
         self._on_conn_change()
 
@@ -204,19 +209,12 @@ class Peer(object):
         return "%s:%d" % (self.host, self.port)
 
     @property
-    def connections(self):
-        """Returns an iterator over all connections for this peer.
-
-        Incoming connections are listed first."""
-        return list(self._connections)
-
-    @property
     def outgoing_connections(self):
         """Returns a list of all outgoing connections for this peer."""
 
         # Outgoing connections are on the right
         return list(
-            dropwhile(lambda c: c.direction != OUTGOING, self._connections)
+            dropwhile(lambda c: c.direction != OUTGOING, self.connections)
         )
 
     @property
@@ -225,17 +223,13 @@ class Peer(object):
 
         # Incoming connections are on the left.
         return list(
-            takewhile(lambda c: c.direction == INCOMING, self._connections)
+            takewhile(lambda c: c.direction == INCOMING, self.connections)
         )
 
     @property
     def total_outbound_pendings(self):
         """Return the total number of out pending req/res among connections"""
-        num = 0
-        for con in self.connections:
-            num += con.total_outbound_pendings
-
-        return num
+        return sum(c.total_outbound_pendings for c in self.connections)
 
     @property
     def is_ephemeral(self):
@@ -246,10 +240,10 @@ class Peer(object):
     def connected(self):
         """Return True if this Peer is connected."""
 
-        return len(self._connections) > 0
+        return len(self.connections) > 0
 
     def close(self):
-        for connection in list(self._connections):
+        for connection in self.connections:
             # closing the connection will mutate the deque so create a copy
             connection.close()
 

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -243,7 +243,7 @@ class Peer(object):
         return len(self.connections) > 0
 
     def close(self):
-        for connection in self.connections:
+        for connection in list(self.connections):
             # closing the connection will mutate the deque so create a copy
             connection.close()
 

--- a/tests/tornado/test_peer.py
+++ b/tests/tornado/test_peer.py
@@ -31,8 +31,6 @@ from tornado import gen
 from tchannel import TChannel
 from tchannel.errors import NoAvailablePeerError
 from tchannel.tornado import peer as tpeer
-from tchannel.tornado import Request
-from tchannel.tornado import Response
 from tchannel.tornado.connection import TornadoConnection
 from tchannel.tornado.peer import Peer
 from tchannel.tornado.stream import InMemStream
@@ -252,13 +250,13 @@ def test_outbound_pending_change():
         outbound_pending_change_callback
     )
 
-    connection.add_outbound_pending_req(Request())
+    connection.add_pending_outbound()
     assert c[0] == 1
-    connection.add_outbound_pending_res(Response())
+    connection.add_pending_outbound()
     assert c[0] == 2
-    connection.remove_outbound_pending_req(Request())
+    connection.remove_pending_outbound()
     assert c[0] == 3
-    connection.remove_outbound_pending_res(Response())
+    connection.remove_pending_outbound()
     assert c[0] == 4
 
 
@@ -276,13 +274,13 @@ def test_outbound_pending_change_propagate(peer):
 
     peer.set_on_conn_change_callback(conn_change_db)
 
-    connection.add_outbound_pending_req(Request())
+    connection.add_pending_outbound()
     assert b[0] == 1
-    connection.add_outbound_pending_res(Response())
+    connection.add_pending_outbound()
     assert b[0] == 2
-    connection.remove_outbound_pending_req(Request())
+    connection.remove_pending_outbound()
     assert b[0] == 3
-    connection.remove_outbound_pending_res(Response())
+    connection.remove_pending_outbound()
     assert b[0] == 4
 
 


### PR DESCRIPTION
This adds minor improvements to the peer selection code that makes the change cheaper:

- Track number of pending outbound requests and responses as an integer rather than two dictionaries.
- Don't allocate new lists of connections when recalculating rank.

CC @junchaowu @blampe @breerly 

----

This is a PR against the peer-selection-cherrypick branch (#393).