### PR TITLE
vcr: Use ttl of the original request for VCR proxy requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes by Version
 0.22.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- VCR now respects the timeout specified on the original request. Timeouts in
+  making the requests while recording now propagate as ``TimeoutError``
+  exceptions rather than ``RemoteServiceError``.
 
 
 0.22.1 (2016-04-06)

--- a/tchannel/testing/vcr/patch.py
+++ b/tchannel/testing/vcr/patch.py
@@ -103,7 +103,9 @@ class PatchedClientOperation(object):
             vcr_response_future = tchannel.thrift(
                 proxy.VCRProxy.send(vcr_request),
                 hostport=self.vcr_hostport,
-                timeout=1.0,
+                timeout=float(ttl) * 1.1 if ttl else ttl,
+                # If a timeout was specified, use that plus 10% to give some
+                # leeway to the VCR proxy request itself.
             )
 
         try:

--- a/tchannel/testing/vcr/server.py
+++ b/tchannel/testing/vcr/server.py
@@ -125,8 +125,12 @@ class VCRProxyService(object):
 
         if not peers:
             raise proxy.NoPeersAvailableError(
-                'Both, hostPort and knownPeers were empty or unset. '
-                'One of them must be specified and non-empty.'
+                'Could not find a recorded response for request %s and was '
+                'unable to make a new request because both, hostPort and '
+                'knownPeers were unspecified. One of them must be specified '
+                'for me to make new requests. Make sure you specified a '
+                'hostport in the original request or are advertising '
+                'on Hyperbahn.' % (str(request),)
             )
 
         arg_scheme = proxy.ArgScheme.name_of(request.argScheme).lower()

--- a/tests/mock_server.py
+++ b/tests/mock_server.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 import threading
 
 import tornado.ioloop
+from tornado import gen
 
 from tchannel import TChannel
 from tchannel import Response
@@ -54,13 +55,16 @@ class Expectation(object):
     def __init__(self):
         self.execute = None
 
-    def and_write(self, body, headers=None):
+    def and_write(self, body, headers=None, delay=None):
 
+        @gen.coroutine
         def execute(request, response):
             if headers:
                 response.headers = headers
             response.body = body
-            return response
+            if delay:
+                yield gen.sleep(delay)
+            raise gen.Return(response)
 
         self.execute = execute
         return self


### PR DESCRIPTION
Rather than using a hard-coded one second timeout, we should use whatever
the user specified for that request.

(I also made the error message for NoPeersAvailableError more informative.)