### PR TITLE
Fix opentracing dependency to 1.0rc4 in anticipation of API changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'threadloop>=1,<2',
 
         # tracing deps
-        'opentracing>=1.0rc4,<2'
+        'opentracing==1.0rc4'
     ],
     extras_require={
         'vcr': ['PyYAML', 'mock', 'wrapt'],


### PR DESCRIPTION
There is a [large API change](https://github.com/opentracing/opentracing.github.io/pull/100) coming soon to OpenTracing, so it's best to pin the API version to RC4 to avoid breaking people.