### PR TITLE
Protect against "socket is None" in iostream.close() with try/catch

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -310,6 +310,9 @@ class TornadoConnection(object):
 
     def close(self):
         if not self.closed:
+            # TODO this is a temporary fix against "socket is None" error
+            # that randomly happens in vcr-related tests.
+            # https://github.com/uber/tchannel-python/issues/416
             try:
                 self.connection.close()
             except:

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -310,7 +310,10 @@ class TornadoConnection(object):
 
     def close(self):
         if not self.closed:
-            self.connection.close()
+            try:
+                self.connection.close()
+            except:
+                log.exception('Error when closing connection')
             self.closed = True
 
     @tornado.gen.coroutine


### PR DESCRIPTION
Temporary fix for #416