### PR TITLE
Set Trace.parent_id to 0 if it's None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.27.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Bug fix: set Trace.parent_id to 0 if it's None
 
 
 0.27.0 (2016-08-08)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2016.2.28        # via tornado
 contextlib2==0.5.1        # via opentracing-instrumentation
 crcmod==1.7
 futures==3.0.5            # via opentracing, opentracing-instrumentation
-opentracing-instrumentation==2.0.0
+opentracing-instrumentation==2.0.1
 opentracing==1.1.0        # via opentracing-instrumentation
 ply==3.8                  # via thriftrw
 singledispatch==3.4.0.3   # via tornado

--- a/tchannel/tracing.py
+++ b/tchannel/tracing.py
@@ -233,7 +233,7 @@ def span_to_tracing_field(span):
         span.tracer.inject(span, ZIPKIN_SPAN_FORMAT, carrier)
         tracing = Tracing(span_id=carrier['span_id'],
                           trace_id=carrier['trace_id'],
-                          parent_id=carrier['parent_id'],
+                          parent_id=carrier['parent_id'] or 0L,
                           traceflags=carrier['traceflags'])
         return tracing
     except opentracing.UnsupportedFormatException:


### PR DESCRIPTION
Fixes #427

@abhinav @blampe let's release it asap as it's breaking people who upgrade to 0.27, and then think how to add tests catching this.