### PR TITLE
Use latest Go crossdock build

### DIFF
--- a/crossdock/docker-compose.yml
+++ b/crossdock/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - REPORT=list
 
     go:
-        image: tchannelhub/xdock-go:crossdock-in-travis
+        image: tchannelhub/xdock-go:dev
         ports:
             - "8080-8082"
 


### PR DESCRIPTION
Have to use 'dev' instead of 'latest' since python-go does not update master branch often