### PR TITLE
advertise: Jitter and request debouncing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,11 @@ Changes by Version
 0.27.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Don't send more Hyperbahn advertise requests if an existing request is
+  ongoing.
+- Add jitter between Hyperbahn consecutive advertise requests.
+- If the initial advertise request fails, propagate the original error instead
+  of a timeout error.
 
 0.27.1 (2016-08-10)
 -------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changes by Version
 ==================
 
-0.27.2 (unreleased)
+0.28.0 (unreleased)
 -------------------
 
 - Don't send more Hyperbahn advertise requests if an existing request is

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,19 @@ class _MockConnection(object):
         pass
 
 
+@pytest.yield_fixture(autouse=True)
+def _reduce_ad_jitter():
+    from tchannel.tornado import hyperbahn
+    # For all tests, reduce jitter to 0.5 seconds so they don't take too long
+    # to run.
+    original = hyperbahn.DEFAULT_INTERVAL_MAX_JITTER_SECS
+    try:
+        hyperbahn.DEFAULT_INTERVAL_MAX_JITTER_SECS = 0.5
+        yield
+    finally:
+        hyperbahn.DEFAULT_INTERVAL_MAX_JITTER_SECS = original
+
+
 @pytest.fixture
 def connection():
     """Make a mock connection."""

--- a/tests/sync/test_client.py
+++ b/tests/sync/test_client.py
@@ -24,7 +24,7 @@ import pytest
 from tchannel import thrift
 from tchannel import TChannel as AsyncTchannel
 from tchannel.sync import TChannel
-from tchannel.errors import TimeoutError, BadRequestError
+from tchannel.errors import UnexpectedError, BadRequestError
 
 
 @pytest.mark.integration
@@ -104,7 +104,7 @@ def test_failing_advertise_should_raise(mock_server):
     routers = [mock_server.tchannel.hostport]
     client = TChannel('test-client')
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(UnexpectedError):
         future = client.advertise(routers, timeout=0.1)
         future.result()
 

--- a/tests/test_hyperbahn_blackhole.py
+++ b/tests/test_hyperbahn_blackhole.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2016 Uber Technologies, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from __future__ import (
+    absolute_import, print_function, unicode_literals, division
+)
+
+from tchannel import TChannel
+from tchannel.tornado import hyperbahn
+
+import pytest
+from tornado import gen
+
+
+class HyperbahnBlackhole(object):
+
+    def __init__(self, count=None):
+        if count is None:
+            count = 10
+
+        self.tchannels = [TChannel('hyperbahn') for x in xrange(count)]
+        self.ad_count = 0
+
+        for tch in self.tchannels:
+            tch.json.register('ad')(self._advertise_blackhole)
+
+    @gen.coroutine
+    def _advertise_blackhole(self, request):
+        self.ad_count += 1
+
+        # succeed the first ad attempt so that we start the loop
+        if self.ad_count == 1:
+            raise gen.Return({})
+
+        # don't respond to any other ads
+        yield gen.sleep(10000)
+
+    @property
+    def peers(self):
+        return [tch.hostport for tch in self.tchannels]
+
+    def start(self):
+        for tch in self.tchannels:
+            tch.listen()
+
+    def stop(self):
+        for tch in self.tchannels:
+            tch.close()
+
+
+@pytest.yield_fixture
+def blackhole(io_loop):
+    hb = HyperbahnBlackhole()
+    try:
+        hb.start()
+        yield hb
+    finally:
+        hb.stop()
+
+
+@pytest.mark.gen_test
+def test_ad_blackhole(blackhole, monkeypatch):
+    # start new ad requests more frequently
+    monkeypatch.setattr(hyperbahn, 'DELAY', 100)  # milliseconds
+    monkeypatch.setattr(hyperbahn, 'PER_ATTEMPT_TIMEOUT', 5)  # seconds
+
+    # No jitter
+    monkeypatch.setattr(hyperbahn, 'DEFAULT_INTERVAL_MAX_JITTER_SECS', 0.0)
+
+    # verify that we don't go crazy if Hyperbahn starts blackholing requests.
+    client = TChannel('client')
+    client.advertise(routers=blackhole.peers)
+    yield gen.sleep(0.5)
+
+    # The second ad request is still ongoing so no other ads should have been
+    # made.
+    assert 2 == blackhole.ad_count


### PR DESCRIPTION
This contains a series of fixes for our Hyperbahn advertise logic:

-   Don't start new `ad` requests if an existing request is ongoing.
-   Instead of retrying each request, let the next scheduled `ad` request take
    over if a request fails.
-   Add up to 5 seconds of jitter before the initial `ad` request. This will
    ensure that if lots of instances of the same service come up at the same
    time, they don't send `ad`s at the same time. Instead, they spread it out
    over 5 seconds.
-   Apply the same jitter to the interval for all consecutive `ad` requests.
    So instead of sending a request every 3 minutes, we'll send a request
    every 3 minutes plus up to 5 seconds.
-   If the initial `ad` request failed, instead of propagating a timeout
    error, propagate the real error.

Resolves https://github.com/uber/tchannel-python/issues/431

CC @blampe @breerly @kriskowal