### PR TITLE
vcr: Ignore tracing headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Changes by Version
 - Add jitter between Hyperbahn consecutive advertise requests.
 - If the initial advertise request fails, propagate the original error instead
   of a timeout error.
+- VCR should ignore tracing headers when matching requests. This will allow
+  replaying requests with or without tracing regardless of whether the original
+  request was recorded with it.
+
 
 0.27.1 (2016-08-10)
 -------------------

--- a/tests/testing/vcr/integration/data/old_with_tracing.yaml
+++ b/tests/testing/vcr/integration/data/old_with_tracing.yaml
@@ -1,0 +1,19 @@
+interactions:
+- request:
+    argScheme: 1
+    body: '"world"'
+    endpoint: !!python/unicode 'hello'
+    headers: '{"$tracing$uber-trace-id": "ca18ff55ca2d44ac:ca18ff55ca2d44ac:0:1"}'
+    hostPort: localhost:54324
+    knownPeers: []
+    serviceName: !!python/unicode 'hello_service'
+    transportHeaders:
+    - key: as
+      value: json
+    - key: cn
+      value: client
+  response:
+    body: '"world"'
+    code: 0
+    headers: '{}'
+version: 1

--- a/tests/testing/vcr/integration/data/old_without_tracing.yaml
+++ b/tests/testing/vcr/integration/data/old_without_tracing.yaml
@@ -1,0 +1,19 @@
+interactions:
+- request:
+    argScheme: 1
+    body: '"world"'
+    endpoint: !!python/unicode 'hello'
+    headers: '{}'
+    hostPort: localhost:58493
+    knownPeers: []
+    serviceName: !!python/unicode 'hello_service'
+    transportHeaders:
+    - key: as
+      value: json
+    - key: cn
+      value: client
+  response:
+    body: '"world"'
+    code: 0
+    headers: '{}'
+version: 1


### PR DESCRIPTION
This changes VCR to always ignore tracing headers when matching application
headers. This will allow VCR to function regardless of whether the original or
the replayed requests have tracing enabled or disabled.

Resolves #430

@blampe @breerly @yurishkuro