### PR TITLE
vcr: Ignore tracing headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changes by Version
 ==================
 
+0.27.2 (unreleased)
+-------------------
+
+- VCR should ignore tracing headers when matching requests. This will allow
+  replaying requests with or without tracing regardless of whether the original
+  request was recorded with it.
+
+
 0.27.1 (2016-08-10)
 -------------------
 

--- a/tests/testing/vcr/integration/data/old_with_tracing.yaml
+++ b/tests/testing/vcr/integration/data/old_with_tracing.yaml
@@ -1,0 +1,19 @@
+interactions:
+- request:
+    argScheme: 1
+    body: '"world"'
+    endpoint: !!python/unicode 'hello'
+    headers: '{"$tracing$uber-trace-id": "ca18ff55ca2d44ac:ca18ff55ca2d44ac:0:1"}'
+    hostPort: localhost:54324
+    knownPeers: []
+    serviceName: !!python/unicode 'hello_service'
+    transportHeaders:
+    - key: as
+      value: json
+    - key: cn
+      value: client
+  response:
+    body: '"world"'
+    code: 0
+    headers: '{}'
+version: 1

--- a/tests/testing/vcr/integration/data/old_without_tracing.yaml
+++ b/tests/testing/vcr/integration/data/old_without_tracing.yaml
@@ -1,0 +1,19 @@
+interactions:
+- request:
+    argScheme: 1
+    body: '"world"'
+    endpoint: !!python/unicode 'hello'
+    headers: '{}'
+    hostPort: localhost:58493
+    knownPeers: []
+    serviceName: !!python/unicode 'hello_service'
+    transportHeaders:
+    - key: as
+      value: json
+    - key: cn
+      value: client
+  response:
+    body: '"world"'
+    code: 0
+    headers: '{}'
+version: 1


### PR DESCRIPTION
This changes VCR to always ignore tracing headers when matching application
headers. This will allow VCR to function regardless of whether the original or
the replayed requests have tracing enabled or disabled.

This is a backport of #433 to the 0.27 release.

Resolves #430