### PR TITLE
Ignore Tracing field with empty/zero TraceID

### DIFF
--- a/crossdock/server/server.py
+++ b/crossdock/server/server.py
@@ -69,6 +69,7 @@ def register_tchannel_handlers(tchannel):
     @tchannel.thrift.register(thrift_service.SimpleService, method='Call')
     @tornado.gen.coroutine
     def thrift_trace_handler(request):
+        logging.info('Received thrift request: %s', request.body.arg.s2)
         req = json.loads(request.body.arg.s2)
         res = yield _process_request(req)
         data = thrift_service.Data(b1=False, i3=0, s2=json.dumps(res))
@@ -89,6 +90,7 @@ def register_tchannel_handlers(tchannel):
 
 def observe_span():
     span = get_current_span()
+    logging.info('Observed span: %s', span)
     if span is None:
         return api.ObservedSpan(traceId='missing', sampled=False, baggage='')
     return api.ObservedSpan(

--- a/tchannel/tracing.py
+++ b/tchannel/tracing.py
@@ -114,12 +114,15 @@ class ServerTracer(object):
         """
         # noinspection PyBroadException
         try:
-            context = self.tracer.extract(
-                format=ZIPKIN_SPAN_FORMAT,
-                carrier=request.tracing)
-            self.span = self.tracer.start_span(
-                operation_name=request.endpoint,
-                child_of=context)
+            # Currently Java does not populate Tracing field, so do not
+            # mistaken it for a real trace ID.
+            if request.tracing.trace_id:
+                context = self.tracer.extract(
+                    format=ZIPKIN_SPAN_FORMAT,
+                    carrier=request.tracing)
+                self.span = self.tracer.start_span(
+                    operation_name=request.endpoint,
+                    child_of=context)
         except opentracing.UnsupportedFormatException:
             pass  # tracer might not support Zipkin format
         except:


### PR DESCRIPTION
Found this issue when testing with Java crossdock tests, because Java does not populate the Tracing field in the frame.

@abhinav 