### PR TITLE
Do not publish `crossdock` module, it's for tests only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    packages=find_packages(exclude=['crossdock', 'tests', 'tests.*']),
     package_data={
         '': ['*.thrift'],
     },


### PR DESCRIPTION
I ran into similar issue with jaeger-client-python, but forgot to apply it here. The published egg should not contain `crossdock` module.

@abhinav 