### PR TITLE
Validate that the headers object is actually a dict

### DIFF
--- a/tchannel/tracing.py
+++ b/tchannel/tracing.py
@@ -140,7 +140,7 @@ class ServerTracer(object):
         parent_context = None
         # noinspection PyBroadException
         try:
-            if headers:
+            if headers and hasattr(headers, 'iteritems'):
                 tracing_headers = {
                     k[len(TRACING_KEY_PREFIX):]: v
                     for k, v in headers.iteritems()


### PR DESCRIPTION
When used with Raw encoding, the headers parameter contains
an unparsed string, and it was causing exceptions.

cc @abhinav 