### PR TITLE
Backport raw headers fix to 0.28

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changes by Version
 ==================
 
+0.28.2 (unreleased)
+-------------------
+
+- Bug fix: Tracing headers will no longer be added for raw requests if the
+  headers are unparsed.
+
 0.28.1 (2016-08-19)
 -------------------
 

--- a/tchannel/tracing.py
+++ b/tchannel/tracing.py
@@ -140,7 +140,7 @@ class ServerTracer(object):
         parent_context = None
         # noinspection PyBroadException
         try:
-            if headers:
+            if headers and hasattr(headers, 'iteritems'):
                 tracing_headers = {
                     k[len(TRACING_KEY_PREFIX):]: v
                     for k, v in headers.iteritems()


### PR DESCRIPTION
This backports Yuri's change from #443 to the 0.28 release.

CC @yurishkuro @breerly @blampe