### PR TITLE
Pass span.kind tag when calling start_span(), not after the span was started

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.29.1 (unreleased)
 -------------------
 
-- Pass span.kind tag when calling start_span(), not after
+- Pass span.kind tag when calling start_span(), not after the span was started.
 
 
 0.29.0 (2016-09-12)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.29.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Pass span.kind tag when calling start_span(), not after
 
 
 0.29.0 (2016-09-12)

--- a/tchannel/tracing.py
+++ b/tchannel/tracing.py
@@ -122,7 +122,9 @@ class ServerTracer(object):
                     carrier=request.tracing)
                 self.span = self.tracer.start_span(
                     operation_name=request.endpoint,
-                    child_of=context)
+                    child_of=context,
+                    tags={tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER},
+                )
         except opentracing.UnsupportedFormatException:
             pass  # tracer might not support Zipkin format
         except:
@@ -160,9 +162,9 @@ class ServerTracer(object):
         if self.span is None:
             self.span = self.tracer.start_span(
                 operation_name=request.endpoint,
-                child_of=parent_context
+                child_of=parent_context,
+                tags={tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER},
             )
-        self.span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_SERVER)
         if 'cn' in request.headers:
             self.span.set_tag(tags.PEER_SERVICE, request.headers['cn'])
         if peer_host:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -477,8 +477,12 @@ def test_span_tags(encoding, operation, tracer, thrift_service):
         yield tornado.gen.sleep(0.001)  # yield execution and sleep for 1ms
     spans = tracer.reporter.get_spans()
     assert len(spans) == 3
-    assert 1 == len(set([s.trace_id for s in spans])), \
-        'all spans must have the same trace_id'
+    trace_ids = set([s.trace_id for s in spans])
+    assert 1 == len(trace_ids), \
+        'all spans must have the same trace_id: %s' % trace_ids
+    span_ids = set([s.span_id for s in spans])
+    assert 2 == len(span_ids), \
+        'must have two unique span IDs, root span and RPC span: %s' % span_ids
     parent = child = None
     for s in spans:
         if s.tags is None:


### PR DESCRIPTION
Zipkin convention is to share span ID between client and server spans. Given OpenTracing API, that's only possible if `span.kind` tag is set when creating the span via `start_span()` method, not after.
