### PR TITLE
Remove call to Github API to get current branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,14 +43,11 @@ after_success:
 
 after_success:
 - export REPO=tchannelhub/xdock-py
-- export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
-- echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
 - export DOCKER=$(if [ "$TOX_ENV" == "crossdock" ]; then echo docker; else echo true; fi)
 - $DOCKER login -u $DOCKER_USER -p $DOCKER_PASS
 - $DOCKER build -f crossdock/Dockerfile -t $REPO:$COMMIT .
 - $DOCKER tag $REPO:$COMMIT $REPO:$TAG
 - $DOCKER tag $REPO:$COMMIT $REPO:travis-$TRAVIS_BUILD_NUMBER
 - $DOCKER push $REPO
-


### PR DESCRIPTION
Now that Travis has shipped travis-ci/travis-ci#1633, we don't need to make a call to the Github API to get the current branch name from both PUSH and PR builds.