### PR TITLE
Relax opentracing upper bound to next major

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changes by Version
 0.30.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Relax opentracing upper bound to next major
 
 
 0.30.0 (2016-09-29)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'threadloop>=1,<2',
 
         # tracing deps
-        'opentracing>=1.1,<1.2',
+        'opentracing>=1.1,<2',
         'opentracing_instrumentation>=2,<3',
     ],
     extras_require={


### PR DESCRIPTION
@abhinav @blampe  can we release this asap?  It's breaking pip-compile for a number of services after recent opentracing upgrade.