### PR TITLE
peer selection: Never choose ephemeral peers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changes by Version
 0.30.1 (unreleased)
 -------------------
 
-- Relax opentracing upper bound to next major
+- Relax opentracing upper bound to next major.
+- Never send requests to ephemeral peers.
 
 
 0.30.0 (2016-09-29)

--- a/tchannel/peer_strategy.py
+++ b/tchannel/peer_strategy.py
@@ -51,7 +51,7 @@ class PreferIncomingCalculator(RankCalculator):
         :param peer: instance of `tchannel.tornado.peer.Peer`
         :return: rank of the peer
         """
-        if peer.is_ephemeral or not peer.connections:
+        if not peer.connections:
             return self.TIERS[0]
 
         if not peer.has_incoming_connections:

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -233,7 +233,7 @@ class Peer(object):
     @property
     def is_ephemeral(self):
         """Whether this Peer is ephemeral."""
-        return self.host == '0.0.0.0' and self.port == 0
+        return self.host == '0.0.0.0' or self.port == 0
 
     @property
     def connected(self):
@@ -706,5 +706,5 @@ class PeerGroup(object):
             return self.get(hostport)
 
         return self.peer_heap.smallest_peer(
-            (lambda p: p.hostport not in blacklist),
+            (lambda p: p.hostport not in blacklist and not p.is_ephemeral),
         )

--- a/tests/test_peer_strategy.py
+++ b/tests/test_peer_strategy.py
@@ -61,18 +61,3 @@ def test_get_rank_with_imcoming():
     calculator = PreferIncomingCalculator()
     peer.register_incoming_conn(connection)
     assert sys.maxint != calculator.get_rank(peer)
-
-
-@pytest.mark.gen_test
-def test_get_rank_ephemeral():
-    server = TChannel('server')
-    server.listen()
-    connection = yield TornadoConnection.outgoing(server.hostport)
-    connection.direction = INCOMING
-    peer = Peer(TChannel('test'), '10.10.101.21:230')
-    peer.register_incoming_conn(connection)
-
-    peer.host = '0.0.0.0'
-    peer.port = 0
-    calculator = PreferIncomingCalculator()
-    assert sys.maxint == calculator.get_rank(peer)


### PR DESCRIPTION
This changes peer selection to never choose ephemeral peers to send requests,
even if that is the only remaining peer.

Additionally, it loosens up the restrictions for what counts as an ephemeral
peer. Either the host can be `0.0.0.0` or the port can be `0` for a peer to be
an ephemeral. This is because Python TChannels that are not listening
advertise themselves as `127.0.0.1:0` (🙁).

---

Note to reviewers: Once this change is approved, I will backport it as a patch
release into older releases.

CC @blampe @breerly @prashantv