### PR TITLE
Propagate message send errors to the caller

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,9 @@ Changes by Version
 0.30.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Propagate message sending errors up to the caller. This should greatly reduce
+  the number of ``TimeoutError: None`` issues seen by users and show the root
+  cause instead.
 
 
 0.30.1 (2016-10-05)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -301,12 +301,9 @@ class TornadoConnection(object):
             message_factory = self.response_message_factory
 
         fragments = message_factory.fragment(message)
-
-        for fragment in fragments:
-            future = self.writer.put(fragment)
-
-        # We're done writing the message once our last future resolves.
-        return future
+        return tornado.gen.multi(
+            self.writer.put(fragment) for fragment in fragments
+        )
 
     def close(self):
         if not self.closed:
@@ -586,12 +583,13 @@ class StreamConnection(TornadoConnection):
             self.remove_pending_outbound()
             response.close_argstreams(force=True)
 
-    def stream_request(self, request):
+    def stream_request(self, request, out_future):
         """send the given request and response is not required"""
         request.close_argstreams()
 
         def on_done(future):
-            future.exception()  # < to avoid "unconsumed exception" logs
+            if future.exception() and out_future.running():
+                out_future.set_exc_info(future.exc_info())
             request.close_argstreams(force=True)
 
         stream_future = self._stream(request, self.request_message_factory)
@@ -617,7 +615,7 @@ class StreamConnection(TornadoConnection):
         future = tornado.gen.Future()
         self._outbound_pending_call[request.id] = future
         self.add_pending_outbound()
-        self.stream_request(request).add_done_callback(
+        self.stream_request(request, future).add_done_callback(
             lambda f: self.remove_pending_outbound()
         )
 
@@ -796,10 +794,15 @@ class Writer(object):
 
     def _enqueue(self, message):
         message.id = message.id or self.next_message_id()
+        done_writing_future = tornado.gen.Future()
 
-        payload = messages.RW[message.message_type].write(
-            message, BytesIO()
-        ).getvalue()
+        try:
+            payload = messages.RW[message.message_type].write(
+                message, BytesIO()
+            ).getvalue()
+        except Exception:
+            done_writing_future.set_exc_info(sys.exc_info())
+            return done_writing_future
 
         f = frame.Frame(
             header=frame.FrameHeader(
@@ -808,9 +811,12 @@ class Writer(object):
             ),
             payload=payload
         )
-        body = frame.frame_rw.write(f, BytesIO()).getvalue()
 
-        done_writing_future = tornado.gen.Future()
+        try:
+            body = frame.frame_rw.write(f, BytesIO()).getvalue()
+        except Exception:
+            done_writing_future.set_exc_info(sys.exc_info())
+            return done_writing_future
 
         def on_queue_error(f):
             if f.exception():
@@ -819,7 +825,6 @@ class Writer(object):
         self.queue.put(
             (body, done_writing_future)
         ).add_done_callback(on_queue_error)
-
         return done_writing_future
 
 ##############################################################################

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -29,6 +29,7 @@ from tornado.iostream import IOStream, StreamClosedError
 
 from tchannel import TChannel
 from tchannel import messages
+from tchannel.tornado.request import Request
 from tchannel.errors import TimeoutError, ReadError
 from tchannel.tornado import connection
 from tchannel.tornado.message_factory import MessageFactory
@@ -276,3 +277,23 @@ def test_reader_read_error():
     future = reader.get()
     with pytest.raises(StreamClosedError):
         yield future
+
+
+@pytest.mark.gen_test
+def test_writer_serialization_error():
+    server = TChannel('server')
+    server.listen()
+
+    conn = yield connection.StreamConnection.outgoing(
+        server.hostport, tchannel=mock.MagicMock()
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+        yield conn.send_request(Request(
+            id=conn.writer.next_message_id(),
+            service='foo',
+            endpoint='bar',
+            headers={'cn': None},
+        ))
+
+    assert "'NoneType' object has no attribute 'encode'" in str(exc_info)


### PR DESCRIPTION
This propagates message serialization and send errors up to the caller so that
we don't see cryptic `TimeoutError: None` exceptions instead.

Before:

```
    [..]
  File "[..]/tchannel-python/tchannel/tornado/peer.py", line 440, in _send
    response = yield response_future
  File "[..]/tchannel-python/env/lib/python2.7/site-packages/tornado-4.4.2-py2.7-macosx-10.11-x86_64.egg/tornado/gen.py", line 1015, in run
    value = future.result()
  File "[..]/tchannel-python/env/lib/python2.7/site-packages/tornado-4.4.2-py2.7-macosx-10.11-x86_64.egg/tornado/concurrent.py", line 237, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
tchannel.errors.TimeoutError: None``
```

After:

```
Traceback (most recent call last):
    [..]
  File "[..]/tchannel-python/tchannel/rw.py", line 574, in length_no_args
    size += rw.length(value)
  File "[..]/tchannel-python/tchannel/rw.py", line 617, in length
    size += self._pair.length(pair)
  File "[..]/tchannel-python/tchannel/rw.py", line 478, in length
    size += link.length(item)
  File "[..]/tchannel-python/tchannel/rw.py", line 446, in length
    s = s.encode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```

@blampe @breerly @prashantv @willhug