### PR TITLE
connection: Fixed fragmentation ordering regression

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changes by Version
 -------------------
 
 - Time out handshake attempts for outgoing connections after 5 seconds.
+- Fixed a regression where large requests would block small requests until they
+  were completely written to the wire.
+- Propagate message sending errors up to the caller. This should greatly reduce
+  the number of ``TimeoutError: None`` issues seen by users and show the root
+  cause instead.
+- Fail ``TChannel`` instantiation if the service name is empty or None.
 
 
 0.30.3 (2016-10-24)

--- a/tchannel/errors.py
+++ b/tchannel/errors.py
@@ -195,3 +195,12 @@ class ValueExpectedError(BadRequestError):
 class SingletonNotPreparedError(TChannelError):
     """Raised when calling get_instance before calling prepare."""
     pass
+
+
+class ServiceNameIsRequiredError(Exception):
+    """Raised when service name is empty or None."""
+
+    def __init__(self):
+        super(ServiceNameIsRequiredError, self).__init__(
+            "service name cannot be empty or None"
+        )

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -33,7 +33,7 @@ from . import schemes
 from . import transport
 from . import retry
 from . import tracing
-from .errors import AlreadyListeningError
+from .errors import AlreadyListeningError, ServiceNameIsRequiredError
 from .glossary import DEFAULT_TIMEOUT
 from .health import health
 from .health import Meta
@@ -101,8 +101,8 @@ class TChannel(object):
             not provided an ephemeral port will be used. When advertising on
             Hyperbahn you callers do not need to know your port.
         """
-        assert name, 'service name cannot be empty or None'
-
+        if not name:
+            raise ServiceNameIsRequiredError
         self.context_provider = context_provider or TracingContextProvider()
 
         # until we move everything here,

--- a/tchannel/tchannel.py
+++ b/tchannel/tchannel.py
@@ -101,6 +101,7 @@ class TChannel(object):
             not provided an ephemeral port will be used. When advertising on
             Hyperbahn you callers do not need to know your port.
         """
+        assert name, 'service name cannot be empty or None'
 
         self.context_provider = context_provider or TracingContextProvider()
 

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -581,7 +581,7 @@ def test_per_request_caller_name_thrift(thrift_module):
     "",
 ])
 def test_service_name_is_required(name, io_loop):
-    with pytest.raises(AssertionError) as exc_info:
+    with pytest.raises(errors.ServiceNameIsRequiredError) as exc_info:
         TChannel(name)
 
     assert 'service name cannot be empty or None' in str(exc_info)

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -576,11 +576,8 @@ def test_per_request_caller_name_thrift(thrift_module):
     assert res.body is True
 
 
-@pytest.mark.parametrize("name", [
-    None,
-    "",
-])
-def test_service_name_is_required(name, io_loop):
+@pytest.mark.parametrize("name", [None, ""])
+def test_service_name_is_required(name):
     with pytest.raises(errors.ServiceNameIsRequiredError) as exc_info:
         TChannel(name)
 

--- a/tests/test_tchannel.py
+++ b/tests/test_tchannel.py
@@ -574,3 +574,14 @@ def test_per_request_caller_name_thrift(thrift_module):
         thrift_module.Service.healthy(), caller_name='bar',
     )
     assert res.body is True
+
+
+@pytest.mark.parametrize("name", [
+    None,
+    "",
+])
+def test_service_name_is_required(name, io_loop):
+    with pytest.raises(AssertionError) as exc_info:
+        TChannel(name)
+
+    assert 'service name cannot be empty or None' in str(exc_info)

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -29,11 +29,11 @@ from tornado.iostream import IOStream, StreamClosedError
 
 from tchannel import TChannel
 from tchannel import messages
-from tchannel.tornado.request import Request
 from tchannel.errors import TimeoutError, ReadError
 from tchannel.tornado import connection
 from tchannel.tornado.message_factory import MessageFactory
 from tchannel.tornado.peer import Peer
+from tchannel.tornado.request import Request
 
 
 def dummy_headers():

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -29,6 +29,7 @@ from tornado.iostream import IOStream, StreamClosedError
 
 from tchannel import TChannel
 from tchannel import messages
+from tchannel.tornado.request import Request
 from tchannel.errors import TimeoutError, ReadError
 from tchannel.tornado import connection
 from tchannel.tornado.message_factory import MessageFactory
@@ -293,3 +294,60 @@ def test_reader_read_error():
     future = reader.get()
     with pytest.raises(StreamClosedError):
         yield future
+
+
+@pytest.mark.gen_test
+def test_writer_serialization_error():
+    server = TChannel('server')
+    server.listen()
+
+    conn = yield connection.StreamConnection.outgoing(
+        server.hostport, tchannel=mock.MagicMock()
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+        yield conn.send_request(Request(
+            id=conn.writer.next_message_id(),
+            service='foo',
+            endpoint='bar',
+            headers={'cn': None},
+        ))
+
+    assert "'NoneType' object has no attribute 'encode'" in str(exc_info)
+
+
+@pytest.mark.gen_test
+def test_writer_multiplexing():
+    server = TChannel('server')
+    server.listen()
+
+    received = {'chunked': False, 'singleframe': False}
+
+    @server.raw.register('chunked')
+    def chunked(request):
+        received['chunked'] = True
+        return b'chunked'
+
+    @server.raw.register('singleframe')
+    def singleframe(request):
+        received['singleframe'] = True
+        return b'singleframe'
+
+    client = TChannel('client')
+
+    chunked_future = client.raw(
+        'server', 'chunked',
+        bytes([0x00] * 1024 * 1024),  # 1 MB = 16 frames
+        hostport=server.hostport,
+        timeout=0.5,
+    )
+
+    yield client.raw(
+        'server', 'singleframe', b'\x00',  # single frame
+        hostport=server.hostport,
+    )
+    assert received['singleframe']
+    assert not received['chunked']
+
+    yield chunked_future
+    assert received['chunked']


### PR DESCRIPTION
This fixes a regression in the behavior of how we handle large messages.
The correct behavior is to multiplex these frames among smaller requests
so that a large request doesn't block all other interaction until it is
done writing. Instead, we were queuing them all back to back. This was
also taking up a lot of memory because all fragments of a large message
would be held in memory until they were all written. With this change,
we won't get to the next fragment until the current fragment has been
serialized and written to the wire (`message_factory.fragment` is a
generator).

This also allows us to revert the revert of 0.30.2 since this takes care
of that memory leak as well. So we should see fewer obscure TimeoutError
exceptions.

CC @blampe @willhug