### PR TITLE
connection: Ensure reader loop keeps running

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -268,10 +268,7 @@ class TornadoConnection(object):
             else:
                 error = self.response_message_factory.build(message)
                 if error:
-                    self.tchannel.event_emitter.fire(
-                        EventType.after_receive_error,
-                        error,
-                    )
+                    log.error('Received error frame %s too late', str(error))
 
         _step()
 

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -198,68 +198,82 @@ class TornadoConnection(object):
         else:
             return self.reader.get()
 
-    @tornado.gen.coroutine
     def _loop(self):
-        # Receive messages off the wire. All messages are either responses to
-        # outstanding requests or calls.
-        #
-        # Must be started only after the handshake has been performed.
-        self._loop_running = True
+        io_loop = IOLoop.current()
 
-        while not self.closed:
-            try:
-                message = yield self.reader.get()
-            except StreamClosedError:
-                break
+        def _step():
+            self._loop_running = not self.closed
+            if self.closed:
+                return
 
-            # TODO: There should probably be a try-catch on the yield.
+            io_loop.add_future(self.reader.get(), _on_message)
+
+        def _on_message(future):
+            # we always schedule a _step call to make sure we never stop
+            # processing messages unless the stream was closed.
+            io_loop.spawn_callback(_step)
+
+            if future.exception():
+                if isinstance(future.exception(), StreamClosedError):
+                    self.close()
+                else:
+                    log.error('Failed to read message',
+                              exc_info=future.exc_info())
+                return
+
+            message = future.result()
             if message.message_type in self.CALL_REQ_TYPES:
                 self._messages.put(message)
-                continue
+                return
 
-            elif message.id in self._outbound_pending_call:
-                # set exception if receive error message
-                if message.message_type == Types.ERROR:
-                    future = self._outbound_pending_call.pop(message.id)
-                    if future.running():
-                        error = TChannelError.from_code(
-                            message.code,
-                            description=message.description,
-                            id=message.id,
-                            tracing=message.tracing,
-                        )
-                        future.set_exception(error)
-                    else:
-                        protocol_exception = (
-                            self.response_message_factory.build(message)
-                        )
-                        if protocol_exception:
-                            self.tchannel.event_emitter.fire(
-                                EventType.after_receive_error,
-                                protocol_exception,
-                            )
-                    continue
+            if message.id in self._outbound_pending_call:
+                _handle_response(message)
+                return
 
-                response = self.response_message_factory.build(message)
-
-                # keep continue message in the list
-                # pop all other type messages including error message
-                if (message.message_type in self.CALL_RES_TYPES and
-                        message.flags == FlagsType.fragment):
-                    # still streaming, keep it for record
-                    future = self._outbound_pending_call.get(message.id)
-                else:
-                    future = self._outbound_pending_call.pop(message.id)
-
-                if response and future.running():
-                    future.set_result(response)
-                continue
-
-            elif message.id in self._request_tombstones:
-                # Recently timed out. Safe to ignore.
-                continue
+            if message.id in self._request_tombstones:
+                return  # recently timed out; safe to ignore
 
             log.info('Unconsumed message %s', message)
+
+        def _handle_response(message):
+            if message.message_type == Types.ERROR:
+                _handle_error_message(message)
+                return
+
+            response = self.response_message_factory.build(message)
+
+            # keep continue message in the list pop all other type messages
+            # including error message
+            if (message.message_type in self.CALL_RES_TYPES and
+                    message.flags == FlagsType.fragment):
+                # still streaming, keep it for record
+                future = self._outbound_pending_call.get(message.id)
+            else:
+                future = self._outbound_pending_call.pop(message.id)
+
+            if response and future.running():
+                future.set_result(response)
+                return
+
+        def _handle_error_message(message):
+            future = self._outbound_pending_call.pop(message.id)
+            if future.running():
+                error = TChannelError.from_code(
+                    message.code,
+                    description=message.description,
+                    id=message.id,
+                    tracing=message.tracing,
+                )
+                future.set_exception(error)
+            else:
+                error = self.response_message_factory.build(message)
+                if error:
+                    self.tchannel.event_emitter.fire(
+                        EventType.after_receive_error,
+                        error,
+                    )
+
+        _step()
 
     # Basically, the only difference between send and write is that send
     # sets up a Future to get the response. That's ideal for peers making
@@ -747,7 +761,7 @@ class Reader(object):
 
         read_message(self.io_stream).add_done_callback(keep_reading)
 
-    def get(self, timeout=None):
+    def get(self):
         """Receive the next message off the wire.
 
         :returns:

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -730,6 +730,7 @@ class StreamConnection(TornadoConnection):
         # while.
         future.set_exception(errors.TimeoutError())
         self._request_tombstones.add(req_id, req_ttl)
+        self._outbound_pending_call.pop(req_id)
 
 
 class Reader(object):


### PR DESCRIPTION
This changes the Connection message reading loop to keep running even in
case of failures. The only time the loop will stop is if the stream was
closed. All other exceptions will be logged and ignored.

CC @blampe @willhug