### PR TITLE
Addressing a couple of nits in the connection-loop branch

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -237,15 +237,15 @@ class TornadoConnection(object):
 
         def _handle_response(message):
             if message.message_type == Types.ERROR:
-                 _handle_error_message(message)
-                 return
+                _handle_error_message(message)
+                return
 
             response = self.response_message_factory.build(message)
 
             # keep continue message in the list pop all other type messages
             # including error message
             if (message.message_type in self.CALL_RES_TYPES and
-                        message.flags == FlagsType.fragment):
+                    message.flags == FlagsType.fragment):
                 # still streaming, keep it for record
                 future = self._outbound_pending_call.get(message.id)
             else:


### PR DESCRIPTION
Namely:
1) change order of the functions so they can be read sequentially
2) Change returns to be on a separate line to clearly state that these
functions don't return anything