### PR TITLE
connection: Don't crash on late error frames

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -267,11 +267,8 @@ class TornadoConnection(object):
                 future.set_exception(error)
             else:
                 error = self.response_message_factory.build(message)
-                if error:
-                    self.tchannel.event_emitter.fire(
-                        EventType.after_receive_error,
-                        error,
-                    )
+                log.error('Received error frame for %d too late %s',
+                          message.id, error)
 
         _step()
 

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -267,8 +267,9 @@ class TornadoConnection(object):
                 future.set_exception(error)
             else:
                 error = self.response_message_factory.build(message)
-                log.error('Received error frame for %d too late %s',
-                          message.id, error)
+                if error:
+                    log.error('Received error frame for %d too late %s',
+                              message.id, error)
 
         _step()
 


### PR DESCRIPTION
If an error frame for a request is received shortly after it times out
and the request has not been evicted from the list of pending calls yet,
this would cause a crash because `after_receive_error` is being called
with one less argument than it expects. `after_receive_error` expects a
request and the error but it is being called with just the error. It's
actually non-trivial to pass the request here because we don't keep
track of it.

We think it's safe to simply log the error rather than trying to call
`after_receive_error` given that it isn't being called right now anyway.

Note that this crash is what was causing the `_loop` to crash previously and
stop processing messages. This should address the crash, plus this code path
will not really be exercised in the future because requests are now evicted
from the pending list when they time out (#461).

@blampe @willhug 