### PR TITLE
connection: timed out requests are not pending

### DIFF
--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -730,6 +730,7 @@ class StreamConnection(TornadoConnection):
         # while.
         future.set_exception(errors.TimeoutError())
         self._request_tombstones.add(req_id, req_ttl)
+        self._outbound_pending_call.pop(req_id)
 
 
 class Reader(object):


### PR DESCRIPTION
Connection maintains a collection of tombstones for requests that
recently timed out so that if we receive a late response for that
request, we know that we can safely discard that message.

Turns out this logic was not actually being exercised most of the time
because the timed out request was left inside the pending requests list.
So when a late response did come for it, the system would think it's
still pending and then discard it anyway without consulting the
tombstones.

This change doesn't actually cause the user-facing behavior to change
significantly. However it most likely does decrease memory pressure a
bit by discarding references to timed out requests earlier.

@blampe @willhug