### PR TITLE
connection: Fix assert loop running errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changes by Version
 0.30.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed a bug which would cause assertion errors if a connection to a peer
+  disconnected shortly after a handshake.
 
 
 0.30.4 (2016-11-03)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -391,6 +391,7 @@ class TornadoConnection(object):
                 "Expected handshake response, got %s" % repr(init_res)
             )
         self._extract_handshake_headers(init_res)
+        self._handshake_performed = True
 
         # The receive loop is started only after the handshake has been
         # completed.
@@ -414,6 +415,7 @@ class TornadoConnection(object):
                 "You need to shake my hand first. Got %s" % repr(init_req)
             )
         self._extract_handshake_headers(init_req)
+        self._handshake_performed = True
 
         self.writer.put(
             messages.InitResponseMessage(
@@ -442,7 +444,6 @@ class TornadoConnection(object):
         self.remote_host_port = int(self.remote_host_port)
         self.remote_process_name = message.process_name
         self.requested_version = message.version
-        self._handshake_performed = True
 
     @classmethod
     @tornado.gen.coroutine

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -367,8 +367,8 @@ def test_loop_failure(tornado_pair):
     yield server.expect_handshake(headers=headers)
     yield handshake_future
 
-    assert client._loop_running
-    assert server._loop_running
+    assert client._handshake_performed
+    assert server._handshake_performed
 
     # We'll put an invalid message into the reader queue. This should cause one
     # iteration of the loop to fail but the system should continue working
@@ -393,8 +393,8 @@ def test_loop_failure(tornado_pair):
     yield server.post_response(response)
     yield response_future
 
-    assert client._loop_running
-    assert server._loop_running
+    assert client._handshake_performed
+    assert server._handshake_performed
 
     client.close()
 
@@ -403,10 +403,7 @@ def test_loop_failure(tornado_pair):
     yield gen.sleep(0.15)
 
     assert client.closed
-    assert not client._loop_running
-
     assert server.closed
-    assert not server._loop_running
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
It seems that there are cases where a handshake is performed and before
the next call is finished, the connection disconnects. Before 0.30.4,
this would cause a StreamClosedError that would be retried, but now that
we're actually updating the `loop_running` variable, it causes an
assertion error.

The only reason we have `loop_running` is to track whether a handshake
was performed. With this change, we track it explicitly and don't unset
it once the handshake is performed. This should address the assertion
error people were seeing.

One of the asserts was removed because it has a `while not self.closed`
loop immediately afterwards, which would cause the loop to end.

@blampe @willhug 