### PR TITLE
Allow peerGroups to maintain one-off hostports without adding them to heap selection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changes by Version
 1.0.1 (unreleased)
 ------------------
 
+- Updated internal APIs to no longer depend on the PeerGroup `add` function
+  and to use the `get` function for creating new peers instead.
 - Fixed a bug where choosing a hostport directly for a downstream call would
   add that peer to the "core" peers which are used for regular calls.
   Now choosing the hostport directly will create a peer but will exclude it

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changes by Version
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed a bug where choosing a hostport directly for a downstream call would
+  add that peer to the "core" peers which are used for regular calls.
+  Now choosing the hostport directly will create a peer but will exclude it
+  from selection.
 
 
 1.0.0 (2016-11-17)

--- a/tchannel/tornado/tchannel.py
+++ b/tchannel/tornado/tchannel.py
@@ -152,7 +152,7 @@ class TChannel(object):
 
         if known_peers:
             for peer_hostport in known_peers:
-                self.peers.add(peer_hostport)
+                self.peers.get(peer_hostport)
 
         # server created from calling listen()
         self._server = None

--- a/tests/tornado/test_tchannel.py
+++ b/tests/tornado/test_tchannel.py
@@ -25,7 +25,6 @@ import socket
 
 from tchannel.errors import AlreadyListeningError
 from tchannel.tornado import TChannel
-from tchannel.tornado.peer import Peer
 
 
 @pytest.fixture
@@ -33,15 +32,10 @@ def tchannel():
     return TChannel(name='test')
 
 
-@pytest.fixture
-def peer(tchannel):
-    return Peer(tchannel, "localhost:4040")
-
-
 @pytest.mark.gen_test
-def test_peer_caching(tchannel, peer):
+def test_peer_caching(tchannel):
     "Connections are long-lived and should not be recreated."""
-    tchannel.peers.add(peer)
+    peer = tchannel.peers.get("localhost:4040")
     assert tchannel.peers.get("localhost:4040") is peer
 
 


### PR DESCRIPTION
Summary: This PR modifies the peerGroup logic so that if a request is
sent directly to a Peer (through a hostport passed through the call
stack) instead of adding that peer to the peer heap, we will create it,
and only keep track of it in the `peers` map (not the peer heap).  This
means we will still maintain the peer, but we won't select it for the
regular hyperbahn instance.

Task: #464