### PR TITLE
Clean/Unlink Queue Nodes from the Queue chain after Queue.get

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changes by Version
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Clear `next` reference of nodes once they have been pulled from message 
+  queues.
 
 
 1.0.1 (2016-12-14)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ test_ci: clean
 ifeq ($(TOX_ENV), crossdock)
 	$(MAKE) crossdock
 else
+	pip install --upgrade setuptools
 	tox -e $(TOX_ENV) -- tests
 endif
 

--- a/tchannel/_queue.py
+++ b/tchannel/_queue.py
@@ -23,7 +23,6 @@ from __future__ import (
 )
 
 import threading
-from collections import namedtuple
 
 from tornado.ioloop import IOLoop
 from tornado.queues import QueueEmpty

--- a/tchannel/_queue.py
+++ b/tchannel/_queue.py
@@ -32,7 +32,17 @@ from tornado.concurrent import Future
 __all__ = ['Queue', 'QueueEmpty']
 
 
-Node = namedtuple('Node', 'value next')
+class Node(object):
+    __slots__ = ('value', 'next')
+
+    def __init__(self, value, next):
+        self.value = value
+        self.next = next
+
+    def __str__(self):
+        return "Node(value=%s, next=%s)" % (self.value, self.next)
+
+    __repr__ = __str__
 
 
 class Queue(object):
@@ -141,7 +151,9 @@ class Queue(object):
             new_get.set_result(hole)
             raise QueueEmpty
 
-        value, new_hole = hole.result()
+        node = hole.result()
+        value = node.value
+        new_hole, node.next = node.next, None
         new_get.set_result(new_hole)
         return value
 
@@ -162,7 +174,9 @@ class Queue(object):
             if future.exception():  # pragma: no cover (never happens)
                 return answer.set_exc_info(future.exc_info())
 
-            value, new_hole = future.result()
+            node = future.result()
+            value = node.value
+            new_hole, node.next = node.next, None
             new_get.set_result(new_hole)
             answer.set_result(value)
 


### PR DESCRIPTION
Summary: There is a memory leak where if the IOLoop holds onto a
reference to any Node (through one of the callbacks) it will cause
that Queue to never be garbage collected.  This PR adjusts the
tchannel queue to delete links in the Node chain.

This diff adjusts the Node objects so we can set the "next" variable to
None when we "get" the node, so any leftover references won't leak all
the subsequent nodes.