### PR TITLE
Run _close_cb if connection is already closed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,10 @@ Changes by Version
 1.0.2 (unreleased)
 ------------------
 
-- Clear `next` reference of nodes once they have been pulled from message 
-  queues.
+- Fixed a race condition where the on_close callback for tchannel connections
+  would not be called if the connection was already closed.
+- Fixed a bug where the reference to the `next` node would not be cleared when
+  nodes were pulled from message queues (Introducing a potential memory leak).
 
 
 1.0.1 (2016-12-14)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -164,6 +164,8 @@ class TornadoConnection(object):
             'A close_callback has already been set for this connection.'
         )
         self._close_cb = stack_context.wrap(cb)
+        if self.closed:
+            self._close_cb()
 
     def _on_close(self):
         self.closed = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ class _MockConnection(object):
         self.buff = bytearray()
         self.remote_host = "0.0.0.0"
         self.remote_host_port = "0"
+        self.closed = False
 
     def write(self, payload, callback=None):
         self.buff.extend(payload)

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -106,6 +106,25 @@ def test_close_callback_is_called():
 
 
 @pytest.mark.gen_test
+def test_close_callback_is_called_immediately_if_already_closed():
+    server = TChannel('server')
+    server.listen()
+
+    cb_future = tornado.gen.Future()
+
+    conn = yield connection.StreamConnection.outgoing(
+        server.hostport, tchannel=mock.MagicMock()
+    )
+    conn.close()
+
+    yield gen.moment
+
+    conn.set_close_callback(lambda: cb_future.set_result(True))
+
+    assert (yield cb_future)
+
+
+@pytest.mark.gen_test
 def test_local_timeout_unconsumed_message():
     """Verify that if the client has a local timeout and the server eventually
     sends the message, the client does not log an "Unconsumed message"

--- a/tests/tornado/test_peer.py
+++ b/tests/tornado/test_peer.py
@@ -193,7 +193,10 @@ def test_peer_connection_failure_exhausted_peers():
 @pytest.mark.gen_test
 def test_peer_incoming_connections_are_preferred(request):
     incoming = mock.MagicMock()
+    incoming.closed = False
+
     outgoing = mock.MagicMock()
+    outgoing.closed = False
 
     peer = tpeer.Peer(mock.MagicMock(), 'localhost:4040')
     with mock.patch(


### PR DESCRIPTION
Summary: Some connections are closing but not getting removed from
the peer list of connections, this is possible because of a race
condition between registering a close function and the connection being
disconnected.  This diff makes it so if you register the close callback
and the connection is already closed, it will immediately run the
callback.