### PR TITLE
Elaborate on TimeoutError(None) errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changes by Version
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added messages with ttl, service, and hostport information to TimeoutErrors
 
 
 1.0.2 (2017-03-20)

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -713,7 +713,11 @@ class StreamConnection(TornadoConnection):
         io_loop = IOLoop.current()
         t = io_loop.call_later(
             request.ttl,
-            self._request_timed_out, request.id, request.service, request.ttl, future,
+            self._request_timed_out,
+            request.id,
+            request.service,
+            request.ttl,
+            future,
         )
         io_loop.add_future(future, lambda f: io_loop.remove_timeout(t))
         # If the future finished before the timeout, we want the IOLoop to
@@ -727,7 +731,8 @@ class StreamConnection(TornadoConnection):
         # Fail the ongoing request and leave a tombstone behind for a short
         # while.
         future.set_exception(errors.TimeoutError(
-            'request to service %s through %s:%d timed out after %s seconds' % (
+            'request to service %s through %s:%d timed out '
+            'after %s seconds' % (
                 str(req_service),
                 str(self.remote_host),
                 self.remote_host_port,

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -713,20 +713,27 @@ class StreamConnection(TornadoConnection):
         io_loop = IOLoop.current()
         t = io_loop.call_later(
             request.ttl,
-            self._request_timed_out, request.id, request.ttl, future,
+            self._request_timed_out, request.id, request.service, request.ttl, future,
         )
         io_loop.add_future(future, lambda f: io_loop.remove_timeout(t))
         # If the future finished before the timeout, we want the IOLoop to
         # forget about it, especially because we want to avoid memory
         # leaks with very large timeouts.
 
-    def _request_timed_out(self, req_id, req_ttl, future):
+    def _request_timed_out(self, req_id, req_service, req_ttl, future):
         if not future.running():  # Already done.
             return
 
         # Fail the ongoing request and leave a tombstone behind for a short
         # while.
-        future.set_exception(errors.TimeoutError())
+        future.set_exception(errors.TimeoutError(
+            'request to service %s through %s:%d timed out after %s seconds' % (
+                str(req_service),
+                str(self.remote_host),
+                self.remote_host_port,
+                str(req_ttl)
+            )
+        ))
         self._request_tombstones.add(req_id, req_ttl)
         self._outbound_pending_call.pop(req_id)
 


### PR DESCRIPTION
Summary: currently with tchannel, if the request times out the error
returned for the request is "TimeoutError(None)" this is not very
helpful with debugging.  This diff changes the error to include:

- Length of the timeout
- Host:Port the request was sent to
- Service they were attempting to call

This doesn't cover everything, but it's a start.