### PR TITLE
Yield hooks, add a new hook to allow modification of application headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changes by Version
 ------------------
 
 - Hook methods can now be implemented as coroutines.
-- Added a new event (`before_send_request_headers`) that can be hooked. This
+- Added a new event (`before_serialize_request_headers`) that can be hooked. This
   is intended to allow application headers to be modified before requests are
   sent.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,10 @@ Changes by Version
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hook methods can now be implemented as coroutines.
+- Added a new event (`before_send_request_headers`) that can be hooked. This
+  is intended to allow application headers to be modified before requests are
+  sent.
 
 
 1.1.0 (2017-04-10)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ setup(
         # tracing deps
         'opentracing>=1.1,<2',
         'opentracing_instrumentation>=2,<3',
+
+        # python 3 compat
+        'six',
     ],
     extras_require={
         'vcr': ['PyYAML', 'mock', 'wrapt'],

--- a/tchannel/event.py
+++ b/tchannel/event.py
@@ -36,6 +36,7 @@ EventType = enum(
     'EventType',
     before_send_request=0x00,
     after_send_request=0x01,
+    before_serialize_request_headers=0x02,
     before_send_response=0x10,
     after_send_response=0x11,
     before_receive_request=0x20,
@@ -61,6 +62,12 @@ class EventHook(object):
                 ....
 
     """
+
+    def before_serialize_request_headers(self, headers):
+        """Called before an outgoing request is serialized.
+        Only to be used for modifying application headers.
+        """
+        pass
 
     def before_send_request(self, request):
         """Called before any part of a ``CALL_REQ`` message is sent."""

--- a/tchannel/event.py
+++ b/tchannel/event.py
@@ -154,7 +154,9 @@ class EventEmitter(object):
     def fire(self, event, *args, **kwargs):
         for hook in self.hooks[event]:
             try:
-                yield tornado.gen.maybe_future(hook(*args, **kwargs))
+                possible_future = hook(*args, **kwargs)
+                if tornado.concurrent.is_future(possible_future):
+                    yield possible_future
             except Exception:
                 log.error("error calling hook", exc_info=sys.exc_info())
 

--- a/tchannel/event.py
+++ b/tchannel/event.py
@@ -63,7 +63,7 @@ class EventHook(object):
 
     """
 
-    def before_serialize_request_headers(self, headers):
+    def before_serialize_request_headers(self, headers, service):
         """Called before an outgoing request is serialized.
         Only to be used for modifying application headers.
         """

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -24,7 +24,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from tornado import gen
+
 from . import JSON
+from ..event import EventType
 from ..serializer.json import JsonSerializer
 from ..tracing import ClientTracer
 
@@ -109,6 +111,11 @@ class JsonArgScheme(object):
         span, headers = self.tracer.start_span(
             service=service, endpoint=endpoint, headers=headers,
             hostport=hostport, encoding='json'
+        )
+
+        yield self.tchannel.event_emitter.fire(
+            EventType.before_send_request_headers,
+            headers,
         )
 
         # serialize

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -116,6 +116,7 @@ class JsonArgScheme(object):
         yield self._tchannel._dep_tchannel.event_emitter.fire(
             EventType.before_serialize_request_headers,
             headers,
+            service,
         )
 
         # serialize

--- a/tchannel/schemes/json.py
+++ b/tchannel/schemes/json.py
@@ -113,8 +113,8 @@ class JsonArgScheme(object):
             hostport=hostport, encoding='json'
         )
 
-        yield self.tchannel.event_emitter.fire(
-            EventType.before_send_request_headers,
+        yield self._tchannel._dep_tchannel.event_emitter.fire(
+            EventType.before_serialize_request_headers,
             headers,
         )
 

--- a/tchannel/schemes/raw.py
+++ b/tchannel/schemes/raw.py
@@ -22,6 +22,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+from ..event import EventType
 from . import RAW
 
 
@@ -102,6 +103,10 @@ class RawArgScheme(object):
 
         :rtype: Response
         """
+        yield self.tchannel.event_emitter.fire(
+            EventType.before_send_request_headers,
+            headers,
+        )
 
         return self._tchannel.call(
             scheme=self.NAME,

--- a/tchannel/schemes/raw.py
+++ b/tchannel/schemes/raw.py
@@ -109,6 +109,7 @@ class RawArgScheme(object):
         yield self._tchannel._dep_tchannel.event_emitter.fire(
             EventType.before_serialize_request_headers,
             headers,
+            service,
         )
 
         response = yield self._tchannel.call(

--- a/tchannel/schemes/raw.py
+++ b/tchannel/schemes/raw.py
@@ -22,6 +22,8 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+from tornado import gen
+
 from ..event import EventType
 from . import RAW
 
@@ -34,6 +36,7 @@ class RawArgScheme(object):
     def __init__(self, tchannel):
         self._tchannel = tchannel
 
+    @gen.coroutine
     def __call__(
         self,
         service,
@@ -103,12 +106,12 @@ class RawArgScheme(object):
 
         :rtype: Response
         """
-        yield self.tchannel.event_emitter.fire(
-            EventType.before_send_request_headers,
+        yield self._tchannel._dep_tchannel.event_emitter.fire(
+            EventType.before_serialize_request_headers,
             headers,
         )
 
-        return self._tchannel.call(
+        response = yield self._tchannel.call(
             scheme=self.NAME,
             service=service,
             arg1=endpoint,
@@ -123,6 +126,8 @@ class RawArgScheme(object):
             routing_delegate=routing_delegate,
             caller_name=caller_name,
         )
+
+        raise gen.Return(response)
 
     def register(self, endpoint, **kwargs):
 

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -26,6 +26,7 @@ from __future__ import unicode_literals
 from tchannel.tracing import ClientTracer
 from tornado import gen
 
+from ..event import EventType
 from . import THRIFT
 
 
@@ -135,6 +136,10 @@ class ThriftArgScheme(object):
             headers=headers, hostport=hostport, encoding='thrift'
         )
 
+        yield self.tchannel.event_emitter.fire(
+            EventType.before_send_request_headers,
+            headers,
+        )
         serializer = request.get_serializer()
 
         # serialize

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -139,6 +139,7 @@ class ThriftArgScheme(object):
         yield self._tchannel._dep_tchannel.event_emitter.fire(
             EventType.before_serialize_request_headers,
             headers,
+            request.service,
         )
         serializer = request.get_serializer()
 

--- a/tchannel/schemes/thrift.py
+++ b/tchannel/schemes/thrift.py
@@ -136,8 +136,8 @@ class ThriftArgScheme(object):
             headers=headers, hostport=hostport, encoding='thrift'
         )
 
-        yield self.tchannel.event_emitter.fire(
-            EventType.before_send_request_headers,
+        yield self._tchannel._dep_tchannel.event_emitter.fire(
+            EventType.before_serialize_request_headers,
             headers,
         )
         serializer = request.get_serializer()

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -533,9 +533,11 @@ class TornadoConnection(object):
         error_message = build_raw_error_message(error)
         write_future = self.writer.put(error_message)
         write_future.add_done_callback(
-            lambda f: self.tchannel.event_emitter.fire(
-                EventType.after_send_error,
-                error,
+            lambda f: IOLoop.current().add_callback(
+                self.tchannel.event_emitter.fire(
+                    EventType.after_send_error,
+                    error,
+                )
             )
         )
         return write_future

--- a/tchannel/tornado/connection.py
+++ b/tchannel/tornado/connection.py
@@ -633,7 +633,7 @@ class StreamConnection(TornadoConnection):
             yield self._stream(response, self.response_message_factory)
 
             # event: send_response
-            self.tchannel.event_emitter.fire(
+            yield self.tchannel.event_emitter.fire(
                 EventType.after_send_response,
                 response,
             )

--- a/tchannel/tornado/dispatch.py
+++ b/tchannel/tornado/dispatch.py
@@ -134,7 +134,8 @@ class RequestDispatcher(object):
 
         tchannel = connection.tchannel
 
-        tchannel.event_emitter.fire(EventType.before_receive_request, request)
+        yield tchannel.event_emitter.fire(
+            EventType.before_receive_request, request)
 
         handler = self.get_endpoint(request.endpoint)
 
@@ -266,7 +267,7 @@ class RequestDispatcher(object):
                 connection.request_message_factory.remove_buffer(response.id)
 
                 connection.send_error(error)
-                tchannel.event_emitter.fire(
+                yield tchannel.event_emitter.fire(
                     EventType.on_exception,
                     request,
                     error,

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -430,7 +430,7 @@ class PeerClientOperation(object):
                 )
         except Exception as e:
             # event: on_exception
-            self.tchannel.event_emitter.fire(
+            yield self.tchannel.event_emitter.fire(
                 EventType.on_exception, request, e,
             )
             raise
@@ -442,7 +442,9 @@ class PeerClientOperation(object):
     @gen.coroutine
     def _send(self, connection, req):
         # event: send_request
-        self.tchannel.event_emitter.fire(EventType.before_send_request, req)
+        yield self.tchannel.event_emitter.fire(
+            EventType.before_send_request, req,
+        )
         response_future = connection.send_request(req)
 
         try:
@@ -454,18 +456,18 @@ class PeerClientOperation(object):
                 tracing=req.tracing,
             )
             # event: after_receive_error
-            self.tchannel.event_emitter.fire(
+            yield self.tchannel.event_emitter.fire(
                 EventType.after_receive_error, req, error,
             )
             raise network_error
         except TChannelError as error:
             # event: after_receive_error
-            self.tchannel.event_emitter.fire(
+            yield self.tchannel.event_emitter.fire(
                 EventType.after_receive_error, req, error,
             )
             raise
         # event: after_receive_response
-        self.tchannel.event_emitter.fire(
+        yield self.tchannel.event_emitter.fire(
             EventType.after_receive_response, req, response,
         )
         raise gen.Return(response)

--- a/tests/tornado/test_connection.py
+++ b/tests/tornado/test_connection.py
@@ -380,7 +380,10 @@ def test_loop_failure(tornado_pair):
 
     # ... yeah
     server.tchannel = mock.MagicMock()
+    server.tchannel.event_emitter.fire.return_value = gen.maybe_future(None)
+
     client.tchannel = mock.MagicMock()
+    client.tchannel.event_emitter.fire.return_value = gen.maybe_future(None)
 
     handshake_future = client.initiate_handshake(headers=headers)
     yield server.expect_handshake(headers=headers)

--- a/tests/tornado/test_dispatch.py
+++ b/tests/tornado/test_dispatch.py
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 import mock
 import pytest
 import tornado.concurrent
+import tornado.gen
 
 from tchannel.event import EventType
 from tchannel.messages.error import ErrorCode
@@ -49,7 +50,9 @@ def req():
 
 @pytest.fixture
 def connection():
-    return mock.MagicMock()
+    connection = mock.MagicMock()
+    connection.tchannel.event_emitter.fire.return_value = tornado.gen.maybe_future(None)
+    return connection
 
 
 @pytest.mark.gen_test

--- a/tests/tornado/test_dispatch.py
+++ b/tests/tornado/test_dispatch.py
@@ -51,7 +51,8 @@ def req():
 @pytest.fixture
 def connection():
     connection = mock.MagicMock()
-    connection.tchannel.event_emitter.fire.return_value = tornado.gen.maybe_future(None)
+    connection.tchannel.event_emitter.fire.return_value = \
+        tornado.gen.maybe_future(None)
     return connection
 
 


### PR DESCRIPTION
It is not currently possible to make hooks asynchronous, since you can't supply a coroutine as a hook method because they wouldn't be yielded properly. This fixes that.