### PR TITLE
peer: Don't send requests to incoming peers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - TOX_ENV=cover
     - TOX_ENV=flake8
     - TOX_ENV=docs
-    - TOX_ENV=benchmark
 
 before_install:
   - make crossdock_install_ci

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Changes by Version
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed a bug which caused servers to send requests to peers that sent requests
+  to them.
 
 
 1.3.0 (2017-11-20)

--- a/tchannel/tornado/peer.py
+++ b/tchannel/tornado/peer.py
@@ -69,6 +69,7 @@ class Peer(object):
         'chosen_count',
         'on_conn_change',
         'connections',
+        'is_incoming',
 
         '_connecting',
         '_on_conn_change_cb',
@@ -104,6 +105,9 @@ class Peer(object):
         #: are added to the left side of the deque and outgoing connections to
         #: the right side.
         self.connections = deque()
+
+        # Whether this peer has incoming connections only.
+        self.is_incoming = False
 
         # This contains a future to the TornadoConnection if we're already in
         # the process of making an outgoing connection to the peer. This
@@ -192,6 +196,7 @@ class Peer(object):
         self.connections.append(conn)
         self._set_on_close_cb(conn)
         self._on_conn_change()
+        self.is_incoming = False
 
     def register_incoming_conn(self, conn):
         """Add incoming connection into the heap."""
@@ -200,6 +205,10 @@ class Peer(object):
         self.connections.appendleft(conn)
         self._set_on_close_cb(conn)
         self._on_conn_change()
+
+        # This is an incoming-only peer if it's already an incoming-only peer,
+        # or if this is the only connection on it.
+        self.is_incoming = self.is_incoming or len(self.connections) == 1
 
     def _on_conn_change(self):
         """Function will be called any time there is connection changes."""
@@ -727,6 +736,11 @@ class PeerGroup(object):
         if hostport:
             return self._get_isolated(hostport)
 
-        return self.peer_heap.smallest_peer(
-            (lambda p: p.hostport not in blacklist and not p.is_ephemeral),
-        )
+        def should_send_requests(p):
+            return not (
+                p.hostport in blacklist or
+                p.is_ephemeral or
+                p.is_incoming
+            )
+
+        return self.peer_heap.smallest_peer(should_send_requests)


### PR DESCRIPTION
This alters peer selection to stop considering peers that send incoming
requests as valid candidates to send outgoing requests to. This was
previously partially fixed in #449 where we stopped considering
ephemeral peers, but non-ephemeral peers are still an issue.

The only peers we should consider for outgoing requests are those we
explicitly added to the peer heap.

Resolves #478