### PR TITLE
test_tracing: Expect 2 or more span IDs

### DIFF
--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -481,7 +481,7 @@ def test_span_tags(encoding, operation, tracer, thrift_service):
     assert 1 == len(trace_ids), \
         'all spans must have the same trace_id: %s' % trace_ids
     span_ids = set([s.span_id for s in spans])
-    assert 2 == len(span_ids), \
+    assert len(span_ids) >= 2, \
         'must have two unique span IDs, root span and RPC span: %s' % span_ids
     parent = child = None
     for s in spans:


### PR DESCRIPTION
An existing test is expecting that exactly 2 unique span IDs are found
in 3 emitted spans. Newer versions of jaeger_client don't appear to have
that beahvior, causing this test to fail.

```
Reporting span 7f1914671d816791:ecb72a8e5bab14b0:f2636dd998a3794d:1 test-tracer.foo
Reporting span 7f1914671d816791:f2636dd998a3794d:7f1914671d816791:1 test-tracer.foo
Reporting span 7f1914671d816791:7f1914671d816791:0:1 test-tracer.root
```

This changes the test to expect at least 2 unique span IDs rather than
exactly two.